### PR TITLE
feat: improve skill scores across 259 skills

### DIFF
--- a/skills/ab-test-analysis/SKILL.md
+++ b/skills/ab-test-analysis/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: A/B Test Analysis
-description: Design and analyze A/B tests, calculate statistical significance, and determine sample sizes for conversion optimization and experiment validation
+name: ab-test-analysis
+description: >
+  Design and analyze A/B tests, calculate statistical significance, and determine sample sizes for conversion optimization and experiment validation.
+  Use when comparing two versions of a product feature, webpage, or marketing campaign, optimizing conversion rates, click-through rates, or user engagement metrics, making data-driven decisions with statistical confidence about changes, or determining sample size requirements for experiment validity.
 ---
 
 # A/B Test Analysis

--- a/skills/accessibility-testing/SKILL.md
+++ b/skills/accessibility-testing/SKILL.md
@@ -2,7 +2,8 @@
 name: accessibility-testing
 description: >
   Test web applications for WCAG compliance and ensure usability for users with
-  disabilities. Use for accessibility test, a11y, axe, ARIA, keyboard
+  disabilities. Use for accessibility test, a11y, axe, ARIA, keyboard.
+  Use when validating wcag 2.1/2.2 compliance, testing keyboard navigation, verifying screen reader compatibility, or testing color contrast ratios.
   navigation, screen reader compatibility, and WCAG validation.
 ---
 

--- a/skills/agile-sprint-planning/SKILL.md
+++ b/skills/agile-sprint-planning/SKILL.md
@@ -2,7 +2,8 @@
 name: agile-sprint-planning
 description: >
   Plan and execute effective sprints using Agile methodologies. Define sprint
-  goals, estimate user stories, manage sprint backlog, and facilitate daily
+  goals, estimate user stories, manage sprint backlog, and facilitate daily.
+  Use when starting a new sprint cycle, defining sprint goals and objectives, estimating user stories and tasks, or managing sprint backlog prioritization.
   standups to maximize team productivity and deliver value incrementally.
 ---
 

--- a/skills/android-kotlin-development/SKILL.md
+++ b/skills/android-kotlin-development/SKILL.md
@@ -2,7 +2,8 @@
 name: android-kotlin-development
 description: >
   Develop native Android apps with Kotlin. Covers MVVM with Jetpack, Compose for
-  modern UI, Retrofit for API calls, Room for local storage, and navigation
+  modern UI, Retrofit for API calls, Room for local storage, and navigation.
+  Use when creating native android applications with best practices, using kotlin for type-safe development, implementing mvvm architecture with jetpack, or building modern uis with jetpack compose.
   architecture.
 ---
 

--- a/skills/angular-module-design/SKILL.md
+++ b/skills/angular-module-design/SKILL.md
@@ -66,13 +66,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Use feature modules to encapsulate related components, services, and routes
+- Lazy-load feature modules via `loadChildren` to reduce initial bundle size
+- Provide services at the appropriate injector level (`providedIn: 'root'` for singletons, module-level for scoped)
+- Separate smart (container) components from presentational (dumb) components
+- Use a `SharedModule` for common pipes, directives, and components re-exported across features
+- Barrel-export (`index.ts`) each feature module's public API to control encapsulation
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Import `BrowserModule` in feature modules — use `CommonModule` instead
+- Declare the same component in multiple modules (move it to a shared module)
+- Put all services in `AppModule` — scope them to the feature that owns the domain
+- Use eager imports for large feature modules that aren't needed at startup

--- a/skills/anomaly-detection/SKILL.md
+++ b/skills/anomaly-detection/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Anomaly Detection
-description: Identify unusual patterns, outliers, and anomalies in data using statistical methods, isolation forests, and autoencoders for fraud detection and quality monitoring
+name: anomaly-detection
+description: >
+  Identify unusual patterns, outliers, and anomalies in data using statistical methods, isolation forests, and autoencoders for fraud detection and quality monitoring.
+  Use when detecting fraudulent transactions or suspicious activity in financial data, identifying system failures, network intrusions, or security breaches, monitoring manufacturing quality and identifying defective products, or finding unusual patterns in healthcare data or patient vital signs.
 ---
 
 # Anomaly Detection

--- a/skills/ansible-automation/SKILL.md
+++ b/skills/ansible-automation/SKILL.md
@@ -2,7 +2,8 @@
 name: ansible-automation
 description: >
   Infrastructure automation and configuration management using Ansible
-  playbooks, roles, and inventory. Use for deploying applications, patching, and
+  playbooks, roles, and inventory. Use for deploying applications, patching, and.
+  Use when configuration management, application deployment, infrastructure patching and updates, or multi-server orchestration.
   managing servers.
 ---
 

--- a/skills/api-contract-testing/SKILL.md
+++ b/skills/api-contract-testing/SKILL.md
@@ -2,7 +2,8 @@
 name: api-contract-testing
 description: >
   Verify API contracts between services to ensure compatibility and prevent
-  breaking changes. Use for contract testing, Pact, API contract validation,
+  breaking changes. Use for contract testing, Pact, API contract validation,.
+  Use when testing microservices communication, preventing breaking api changes, validating api versioning, or testing consumer-provider contracts.
   schema validation, and consumer-driven contracts.
 ---
 

--- a/skills/api-response-optimization/SKILL.md
+++ b/skills/api-response-optimization/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: api-response-optimization
 description: >
-  Optimize API response times through caching, compression, and efficient
+  Optimize API response times through caching, compression, and efficient.
+  Use when slow api response times, high server cpu/memory usage, large response payloads, or performance degradation.
   payloads. Improve backend performance and reduce network traffic.
 ---
 
@@ -75,13 +76,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Return only the fields the client needs — use sparse fieldsets or a projection layer
+- Enable gzip/brotli compression for all JSON responses over 1 KB
+- Set appropriate `Cache-Control` and `ETag` headers for cacheable endpoints
+- Paginate list endpoints and include `total`, `limit`, and `offset` in the response
+- Use HTTP 304 (Not Modified) to avoid re-sending unchanged resources
+- Profile slow queries with `EXPLAIN ANALYZE` and add indexes before caching around them
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Expose internal or sensitive fields (`password_hash`, `ssn`, internal IDs) in API responses
+- Nest related resources deeply — prefer flat payloads or links for associations
+- Cache authenticated or user-specific responses in shared/public caches
+- Rely solely on application-level caching without setting HTTP cache headers

--- a/skills/app-store-deployment/SKILL.md
+++ b/skills/app-store-deployment/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: app-store-deployment
 description: >
-  Deploy iOS and Android apps to App Store and Google Play. Covers signing,
+  Deploy iOS and Android apps to App Store and Google Play. Covers signing,.
+  Use when publishing apps to app store and google play, managing app versions and releases, configuring signing certificates and provisioning profiles, or automating build and deployment processes.
   versioning, build configuration, submission process, and release management.
 ---
 

--- a/skills/artifact-management/SKILL.md
+++ b/skills/artifact-management/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: artifact-management
 description: >
-  Manage build artifacts, Docker images, and package registries. Configure
+  Manage build artifacts, Docker images, and package registries. Configure.
+  Use when docker image registry management, package publication and versioning, build artifact storage and retrieval, or container image optimization.
   artifact repositories, versioning, and distribution strategies.
 ---
 

--- a/skills/autoscaling-configuration/SKILL.md
+++ b/skills/autoscaling-configuration/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: autoscaling-configuration
 description: >
-  Configure autoscaling for Kubernetes, VMs, and serverless workloads based on
+  Configure autoscaling for Kubernetes, VMs, and serverless workloads based on.
+  Use when traffic-driven workload scaling, time-based scheduled scaling, resource utilization optimization, or cost reduction.
   metrics, schedules, and custom indicators.
 ---
 

--- a/skills/aws-cloudfront-cdn/SKILL.md
+++ b/skills/aws-cloudfront-cdn/SKILL.md
@@ -2,7 +2,8 @@
 name: aws-cloudfront-cdn
 description: >
   Distribute content globally using CloudFront with caching, security headers,
-  WAF integration, and origin configuration. Use for low-latency content
+  WAF integration, and origin configuration. Use for low-latency content.
+  Use when static website hosting and assets, api acceleration and dynamic content, video and media streaming, or mobile application content.
   delivery.
 ---
 

--- a/skills/aws-ec2-setup/SKILL.md
+++ b/skills/aws-ec2-setup/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: aws-ec2-setup
 description: >
-  Launch and configure EC2 instances with security groups, IAM roles, key pairs,
+  Launch and configure EC2 instances with security groups, IAM roles, key pairs,.
+  Use when web application servers, application backends and apis, batch processing and compute jobs, or development and testing environments.
   AMIs, and auto-scaling. Use for virtual servers and managed infrastructure.
 ---
 

--- a/skills/aws-lambda-functions/SKILL.md
+++ b/skills/aws-lambda-functions/SKILL.md
@@ -2,7 +2,8 @@
 name: aws-lambda-functions
 description: >
   Create and deploy serverless functions using AWS Lambda with event sources,
-  permissions, layers, and environment configuration. Use for event-driven
+  permissions, layers, and environment configuration. Use for event-driven.
+  Use when api endpoints and webhooks, scheduled batch jobs and data processing, real-time file processing (s3 uploads), or event-driven workflows (sns, sqs).
   computing without managing servers.
 ---
 

--- a/skills/aws-rds-database/SKILL.md
+++ b/skills/aws-rds-database/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: aws-rds-database
 description: >
-  Deploy and manage relational databases using RDS with Multi-AZ, read replicas,
+  Deploy and manage relational databases using RDS with Multi-AZ, read replicas,.
+  Use when postgresql and mysql applications, transactional databases and oltp, oracle and microsoft sql server workloads, or read-heavy applications with replicas.
   backups, and encryption. Use for PostgreSQL, MySQL, MariaDB, and Oracle.
 ---
 

--- a/skills/aws-s3-management/SKILL.md
+++ b/skills/aws-s3-management/SKILL.md
@@ -2,7 +2,8 @@
 name: aws-s3-management
 description: >
   Manage S3 buckets with versioning, encryption, access control, lifecycle
-  policies, and replication. Use for object storage, static sites, and data
+  policies, and replication. Use for object storage, static sites, and data.
+  Use when static website hosting, data backup and archival, media library and cdn origin, or data lake and analytics.
   lakes.
 ---
 

--- a/skills/azure-app-service/SKILL.md
+++ b/skills/azure-app-service/SKILL.md
@@ -2,7 +2,8 @@
 name: azure-app-service
 description: >
   Deploy and manage web apps using Azure App Service with auto-scaling,
-  deployment slots, SSL/TLS, and monitoring. Use for hosting web applications on
+  deployment slots, SSL/TLS, and monitoring. Use for hosting web applications on.
+  Use when web applications (asp.net, node.js, python, java), rest apis and microservices, mobile app backends, or static website hosting.
   Azure.
 ---
 

--- a/skills/azure-functions/SKILL.md
+++ b/skills/azure-functions/SKILL.md
@@ -2,7 +2,8 @@
 name: azure-functions
 description: >
   Create serverless functions on Azure with triggers, bindings, authentication,
-  and monitoring. Use for event-driven computing without managing
+  and monitoring. Use for event-driven computing without managing.
+  Use when http apis and webhooks, message-driven processing (service bus, event hub), scheduled jobs and cron expressions, or file and blob processing.
   infrastructure.
 ---
 

--- a/skills/backup-disaster-recovery/SKILL.md
+++ b/skills/backup-disaster-recovery/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: backup-disaster-recovery
 description: >
-  Implement backup strategies, disaster recovery plans, and data restoration
+  Implement backup strategies, disaster recovery plans, and data restoration.
+  Use when data protection and compliance, business continuity planning, disaster recovery planning, or point-in-time recovery.
   procedures for protecting critical infrastructure and data.
 ---
 

--- a/skills/blue-green-deployment/SKILL.md
+++ b/skills/blue-green-deployment/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: blue-green-deployment
 description: >
-  Implement blue-green deployment strategies for zero-downtime releases with
+  Implement blue-green deployment strategies for zero-downtime releases with.
+  Use when zero-downtime releases, high-risk deployments, complex application migrations, or database schema changes.
   instant rollback capability and traffic switching between environments.
 ---
 
@@ -76,13 +77,15 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Run a full health-check and smoke-test suite against the idle environment before switching traffic
+- Keep both environments identical in infrastructure, config, and dependencies
+- Use database migration strategies that are backward-compatible with both blue and green versions
+- Automate the traffic switch and rollback via a single idempotent script
+- Monitor error rates, latency, and saturation for at least 10 minutes after the switch before decommissioning the old environment
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Switch traffic without verifying the idle environment passes health checks
+- Run destructive database migrations that break the currently-live version (prevents instant rollback)
+- Tear down the previous environment immediately — keep it warm until the new deployment is confirmed stable
+- Assume DNS-based switching is instant; account for TTL propagation delays

--- a/skills/browser-debugging/SKILL.md
+++ b/skills/browser-debugging/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: browser-debugging
 description: >
-  Debug client-side issues using browser developer tools. Identify JavaScript
+  Debug client-side issues using browser developer tools. Identify JavaScript.
+  Use when javascript errors, layout/styling issues, performance problems, or user interaction issues.
   errors, styling issues, and performance problems in the browser.
 ---
 
@@ -76,13 +77,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Use conditional and logpoint breakpoints instead of littering code with `console.log`
+- Reproduce issues in an incognito window to rule out extension interference
+- Check the Network tab for failed requests, CORS errors, and unexpected response codes before debugging JS logic
+- Use the Performance panel's flame chart to pinpoint long tasks blocking the main thread
+- Inspect the Accessibility tree alongside the Elements panel when debugging layout for screen readers
+- Preserve logs across navigations when debugging redirect-related issues
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Leave `debugger` statements or verbose `console.log` calls in committed code
+- Ignore the Console warnings and deprecation notices — they often foreshadow breakage
+- Test only in one browser; verify across Chrome, Firefox, and Safari for cross-browser issues
+- Disable cache in DevTools and forget to re-enable it — this masks caching bugs in production

--- a/skills/bundle-size-optimization/SKILL.md
+++ b/skills/bundle-size-optimization/SKILL.md
@@ -2,7 +2,8 @@
 name: bundle-size-optimization
 description: >
   Reduce JavaScript and CSS bundle sizes through code splitting, tree shaking,
-  and optimization techniques. Improve load times and overall application
+  and optimization techniques. Improve load times and overall application.
+  Use when build process optimization, bundle analysis before deployment, performance baseline improvement, or mobile performance focus.
   performance.
 ---
 
@@ -76,13 +77,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Run `webpack-bundle-analyzer` or `source-map-explorer` before and after changes to measure impact
+- Use dynamic `import()` for routes and heavy components to enable code splitting
+- Prefer tree-shakeable ESM imports (`import { debounce } from 'lodash-es'`) over default/namespace imports
+- Replace large libraries with lighter alternatives (e.g., `date-fns` instead of `moment.js`)
+- Set a bundle size budget in CI and fail the build when it's exceeded
+- Enable scope hoisting and minification in production builds
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Import entire libraries when you only use a few functions (`import _ from 'lodash'`)
+- Add polyfills for APIs already supported by your browser target matrix
+- Include development-only code (source maps, verbose logging) in production bundles
+- Optimize blindly — always measure first to focus effort on the largest chunks

--- a/skills/business-case-development/SKILL.md
+++ b/skills/business-case-development/SKILL.md
@@ -2,7 +2,8 @@
 name: business-case-development
 description: >
   Build compelling business cases to justify investments and secure funding.
-  Quantify benefits, assess costs, manage risks, and present compelling ROI
+  Quantify benefits, assess costs, manage risks, and present compelling ROI.
+  Use when requesting budget approval, justifying technology investments, planning major initiatives, or evaluating vendor solutions.
   arguments to leadership.
 ---
 

--- a/skills/canary-deployment/SKILL.md
+++ b/skills/canary-deployment/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: canary-deployment
 description: >
-  Implement canary deployment strategies to gradually roll out new versions to
+  Implement canary deployment strategies to gradually roll out new versions to.
+  Use when low-risk gradual rollouts, real-world testing with live traffic, automatic rollback on errors, or user impact minimization.
   subset of users with automatic rollback based on metrics.
 ---
 
@@ -77,13 +78,15 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Start with a small traffic percentage (1-5%) and increase incrementally based on metric thresholds
+- Define clear success criteria (error rate, latency p99, saturation) before beginning the rollout
+- Automate rollback triggers so the canary is pulled back within seconds when thresholds are breached
+- Use consistent request routing (sticky sessions or header-based) so individual users don't flip between versions mid-session
+- Compare canary metrics against a baseline from the stable version, not just absolute thresholds
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Skip the bake time — let each traffic increment run long enough to surface slow-burn regressions
+- Route all traffic to the canary at once; that defeats the purpose of gradual rollout
+- Ignore infrastructure metrics (CPU, memory, GC pauses) and focus only on HTTP error rates
+- Deploy canary changes that include backward-incompatible database migrations

--- a/skills/capacity-planning/SKILL.md
+++ b/skills/capacity-planning/SKILL.md
@@ -2,7 +2,8 @@
 name: capacity-planning
 description: >
   Analyze team capacity, plan resource allocation, and balance workload across
-  projects. Forecast staffing needs and optimize team utilization while
+  projects. Forecast staffing needs and optimize team utilization while.
+  Use when annual or quarterly planning cycles, allocating people to projects, adjusting team size, or planning for holidays and absences.
   maintaining sustainable pace.
 ---
 

--- a/skills/causal-inference/SKILL.md
+++ b/skills/causal-inference/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Causal Inference
-description: Determine cause-and-effect relationships using propensity scoring, instrumental variables, and causal graphs for policy evaluation and treatment effects
+name: causal-inference
+description: >
+  Determine cause-and-effect relationships using propensity scoring, instrumental variables, and causal graphs for policy evaluation and treatment effects.
+  Use when evaluating the impact of policy interventions or business decisions, estimating treatment effects when randomized experiments aren't feasible, controlling for confounding variables in observational data, or determining if a marketing campaign or product change caused an outcome.
 ---
 
 # Causal Inference

--- a/skills/cicd-pipeline-setup/SKILL.md
+++ b/skills/cicd-pipeline-setup/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cicd-pipeline-setup
 description: >
-  Design and implement CI/CD pipelines with GitHub Actions, GitLab CI, Jenkins,
+  Design and implement CI/CD pipelines with GitHub Actions, GitLab CI, Jenkins,.
+  Use when automated code testing and quality checks, containerized application builds, multi-environment deployments, or release management and versioning.
   or CircleCI. Use for automated testing, building, and deployment workflows.
 ---
 

--- a/skills/classification-modeling/SKILL.md
+++ b/skills/classification-modeling/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Classification Modeling
-description: Build binary and multiclass classification models using logistic regression, decision trees, and ensemble methods for categorical prediction and classification
+name: classification-modeling
+description: >
+  Build binary and multiclass classification models using logistic regression, decision trees, and ensemble methods for categorical prediction and classification.
+  Use when predicting binary outcomes like customer churn, loan default, or email spam, classifying items into multiple categories such as product types or sentiment, building credit scoring models or risk assessment systems, or identifying disease diagnosis or medical condition from patient data.
 ---
 
 # Classification Modeling

--- a/skills/cloud-cost-management/SKILL.md
+++ b/skills/cloud-cost-management/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cloud-cost-management
 description: >
-  Optimize and manage cloud costs across AWS, Azure, and GCP using reserved
+  Optimize and manage cloud costs across AWS, Azure, and GCP using reserved.
+  Use when reducing cloud infrastructure costs, optimizing compute spending, managing database costs, or storage optimization.
   instances, spot pricing, and cost monitoring tools.
 ---
 

--- a/skills/cloud-migration-planning/SKILL.md
+++ b/skills/cloud-migration-planning/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cloud-migration-planning
 description: >
-  Plan and execute cloud migrations with assessment, database migration,
+  Plan and execute cloud migrations with assessment, database migration,.
+  Use when moving from on-premises to cloud, cloud platform consolidation, legacy system modernization, or reducing data center costs.
   application refactoring, and cutover strategies across AWS, Azure, and GCP.
 ---
 

--- a/skills/cloud-security-configuration/SKILL.md
+++ b/skills/cloud-security-configuration/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cloud-security-configuration
 description: >
-  Implement comprehensive cloud security across AWS, Azure, and GCP with IAM,
+  Implement comprehensive cloud security across AWS, Azure, and GCP with IAM,.
+  Use when protecting sensitive data in cloud, compliance with regulations (gdpr, hipaa, pci-dss), implementing zero-trust security, or securing multi-cloud environments.
   encryption, network security, compliance, and threat detection.
 ---
 

--- a/skills/cloud-storage-optimization/SKILL.md
+++ b/skills/cloud-storage-optimization/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cloud-storage-optimization
 description: >
-  Optimize cloud storage across AWS S3, Azure Blob, and GCP Cloud Storage with
+  Optimize cloud storage across AWS S3, Azure Blob, and GCP Cloud Storage with.
+  Use when reducing storage costs, optimizing data access patterns, implementing tiered storage strategies, or archiving historical data.
   compression, partitioning, lifecycle policies, and cost management.
 ---
 

--- a/skills/clustering-analysis/SKILL.md
+++ b/skills/clustering-analysis/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Clustering Analysis
-description: Identify groups and patterns in data using k-means, hierarchical clustering, and DBSCAN for cluster discovery, customer segmentation, and unsupervised learning
+name: clustering-analysis
+description: >
+  Identify groups and patterns in data using k-means, hierarchical clustering, and DBSCAN for cluster discovery, customer segmentation, and unsupervised learning.
+  Use when segmenting customers based on purchasing behavior or demographics, discovering natural groupings in data without prior knowledge of categories, identifying market segments for targeted marketing campaigns, or organizing large datasets into meaningful categories for further analysis.
 ---
 
 # Clustering Analysis

--- a/skills/cohort-analysis/SKILL.md
+++ b/skills/cohort-analysis/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Cohort Analysis
-description: Track and analyze user cohorts over time, calculate retention rates, and identify behavioral patterns for customer lifecycle and retention analysis
+name: cohort-analysis
+description: >
+  Track and analyze user cohorts over time, calculate retention rates, and identify behavioral patterns for customer lifecycle and retention analysis.
+  Use when measuring user retention rates and identifying when users churn, analyzing customer lifetime value (ltv) and payback periods, comparing performance across different user acquisition channels or campaigns, or understanding how product changes affect different user groups over time.
 ---
 
 # Cohort Analysis

--- a/skills/color-accessibility/SKILL.md
+++ b/skills/color-accessibility/SKILL.md
@@ -2,7 +2,8 @@
 name: color-accessibility
 description: >
   Design color palettes that are accessible to all users including those with
-  color blindness. Ensure sufficient contrast, meaningful use of color, and
+  color blindness. Ensure sufficient contrast, meaningful use of color, and.
+  Use when creating color palettes, designing data visualizations, testing interface designs, or status indicators and alerts.
   inclusive design.
 ---
 

--- a/skills/competitor-analysis/SKILL.md
+++ b/skills/competitor-analysis/SKILL.md
@@ -2,7 +2,8 @@
 name: competitor-analysis
 description: >
   Analyze competitive landscape to identify strengths, weaknesses,
-  opportunities, and threats. Inform product strategy and positioning based on
+  opportunities, and threats. Inform product strategy and positioning based on.
+  Use when product strategy development, market entry planning, pricing strategy, or feature prioritization.
   market insights.
 ---
 

--- a/skills/computer-vision/SKILL.md
+++ b/skills/computer-vision/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Computer Vision
-description: Implement computer vision tasks including image classification, object detection, segmentation, and pose estimation using PyTorch and TensorFlow
+name: computer-vision
+description: >
+  Implement computer vision tasks including image classification, object detection, segmentation, and pose estimation using PyTorch and TensorFlow.
+  Use when image classification and object recognition tasks, object detection and localization in images, semantic or instance segmentation projects, or pose estimation and human activity recognition.
 ---
 
 # Computer Vision

--- a/skills/configuration-management/SKILL.md
+++ b/skills/configuration-management/SKILL.md
@@ -3,7 +3,8 @@ name: configuration-management
 description: >
   Manage application configuration including environment variables, settings
   management, configuration hierarchies, secret management, feature flags, and
-  12-factor app principles. Use for config, environment setup, or settings
+  12-factor app principles. Use for config, environment setup, or settings.
+  Use when setting up configuration for different environments, managing secrets and credentials, implementing feature flags, or creating configuration hierarchies.
   management.
 ---
 

--- a/skills/container-debugging/SKILL.md
+++ b/skills/container-debugging/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: container-debugging
 description: >
-  Debug Docker containers and containerized applications. Diagnose deployment
+  Debug Docker containers and containerized applications. Diagnose deployment.
+  Use when container won't start, application crashes in container, resource limits exceeded, or network connectivity issues.
   issues, container lifecycle problems, and resource constraints.
 ---
 
@@ -75,13 +76,15 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Check `docker logs` and container exit codes first — most issues are visible in the output
+- Use `docker exec` to inspect a running container's filesystem, environment, and network state
+- Compare `docker inspect` output against the expected config (mounts, env vars, network, resource limits)
+- Use ephemeral debug containers (`kubectl debug` or `docker run --rm`) to avoid polluting production images with debug tools
+- Verify DNS resolution and port connectivity from inside the container's network namespace
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Install debug tools (curl, strace, tcpdump) directly into production images — use sidecar or ephemeral containers
+- Ignore OOMKilled signals; increase memory limits or fix the memory leak before restarting
+- Assume the host filesystem matches the container's view — always verify mounts and volume paths
+- Run containers as root in production just to work around permission errors

--- a/skills/container-registry-management/SKILL.md
+++ b/skills/container-registry-management/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: container-registry-management
 description: >
-  Manage container registries (Docker Hub, ECR, GCR) with image scanning,
+  Manage container registries (Docker Hub, ECR, GCR) with image scanning,.
+  Use when container image storage and distribution, security scanning and compliance, image retention and cleanup, or registry access control.
   retention policies, and access control.
 ---
 

--- a/skills/continuous-testing/SKILL.md
+++ b/skills/continuous-testing/SKILL.md
@@ -2,7 +2,8 @@
 name: continuous-testing
 description: >
   Integrate automated testing into CI/CD pipelines for continuous quality
-  feedback. Use for continuous testing, CI testing, automated testing pipelines,
+  feedback. Use for continuous testing, CI testing, automated testing pipelines,.
+  Use when setting up ci/cd pipelines, automating test execution on commits, implementing shift-left testing, or running tests in parallel.
   test orchestration, and DevOps quality practices.
 ---
 

--- a/skills/correlation-analysis/SKILL.md
+++ b/skills/correlation-analysis/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Correlation Analysis
-description: Measure relationships between variables using correlation coefficients, correlation matrices, and association tests for correlation measurement, relationship analysis, and multicollinearity detection
+name: correlation-analysis
+description: >
+  Measure relationships between variables using correlation coefficients, correlation matrices, and association tests for correlation measurement, relationship analysis, and multicollinearity detection.
+  Use when identifying relationships between numerical variables, detecting multicollinearity before regression modeling, exploratory data analysis to understand feature dependencies, or feature selection and dimensionality reduction.
 ---
 
 # Correlation Analysis

--- a/skills/cpu-profiling/SKILL.md
+++ b/skills/cpu-profiling/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cpu-profiling
 description: >
-  Profile CPU usage to identify hot spots and bottlenecks. Optimize code paths
+  Profile CPU usage to identify hot spots and bottlenecks. Optimize code paths.
+  Use when high cpu usage, slow execution, performance regression, or before optimization.
   consuming most CPU time for better performance and resource efficiency.
 ---
 
@@ -75,13 +76,15 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Profile under realistic workloads — synthetic micro-benchmarks hide real-world hot paths
+- Distinguish between "self time" and "total time" in flame charts to find the actual bottleneck
+- Take multiple profile samples and compare to rule out noise from GC pauses or OS scheduling
+- Establish a performance baseline before optimizing so you can measure the actual improvement
+- Profile in production-like environments; dev-mode overhead (source maps, HMR) skews results
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Optimize functions that account for less than 1% of total CPU time — focus on the hot path
+- Profile with browser DevTools extensions enabled; they add overhead and distort measurements
+- Assume a slow function is CPU-bound without checking for I/O waits, lock contention, or GC pressure
+- Commit performance changes without before/after profiling data to validate the improvement

--- a/skills/css-architecture/SKILL.md
+++ b/skills/css-architecture/SKILL.md
@@ -76,13 +76,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Pick one naming methodology (BEM, SMACSS, or utility-first) and enforce it consistently across the project
+- Use CSS custom properties (variables) for colors, spacing, and typography to enable theming
+- Scope styles to components to prevent unintended cascade side-effects
+- Organize stylesheets in layers: reset/base, layout, components, utilities — imported in that order
+- Use a design token system so values stay in sync between design tools and code
+- Audit specificity regularly; keep selectors as flat as possible (ideally single-class)
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Use `!important` to fix specificity wars — refactor the selectors instead
+- Nest selectors more than 2-3 levels deep in preprocessors; it produces fragile, high-specificity output
+- Mix naming conventions (e.g., BEM in some files, ad-hoc in others) within the same project
+- Duplicate style values as magic numbers — extract them into variables or tokens

--- a/skills/data-cleaning-pipeline/SKILL.md
+++ b/skills/data-cleaning-pipeline/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Data Cleaning Pipeline
-description: Build robust processes for data cleaning, missing value imputation, outlier handling, and data transformation for data preprocessing, data quality, and data pipeline automation
+name: data-cleaning-pipeline
+description: >
+  Build robust processes for data cleaning, missing value imputation, outlier handling, and data transformation for data preprocessing, data quality, and data pipeline automation.
+  Use when preparing raw datasets for analysis or modeling, handling missing values and data quality issues, removing duplicates and standardizing formats, or detecting and treating outliers.
 ---
 
 # Data Cleaning Pipeline

--- a/skills/data-replication-setup/SKILL.md
+++ b/skills/data-replication-setup/SKILL.md
@@ -2,7 +2,8 @@
 name: data-replication-setup
 description: >
   Set up database replication for high availability and disaster recovery. Use
-  when configuring master-slave replication, multi-master setups, or replication
+  when configuring master-slave replication, multi-master setups, or replication.
+  Use when high availability setup, disaster recovery planning, read replica configuration, or multi-region replication.
   monitoring.
 ---
 
@@ -65,13 +66,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Monitor replication lag continuously and alert when it exceeds your RPO threshold
+- Test failover and promotion procedures regularly in a staging environment
+- Use dedicated replication users with minimal privileges (REPLICATION role only)
+- Configure WAL archiving or binary log retention alongside streaming replication for point-in-time recovery
+- Document the promotion runbook so any on-call engineer can execute it under pressure
+- Encrypt replication traffic with TLS, especially across regions or untrusted networks
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Write to replica databases — enforce read-only mode to prevent split-brain data corruption
+- Use the same credentials for application access and replication connections
+- Ignore replication slot or binary log disk usage — uncleared slots can fill the primary's disk
+- Assume automatic failover works without testing it; validate the entire promotion path end-to-end

--- a/skills/data-visualization/SKILL.md
+++ b/skills/data-visualization/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Data Visualization
-description: Create effective visualizations using matplotlib and seaborn for exploratory analysis, presenting insights, and communicating findings with business stakeholders
+name: data-visualization
+description: >
+  Create effective visualizations using matplotlib and seaborn for exploratory analysis, presenting insights, and communicating findings with business stakeholders.
+  Use when exploratory data analysis and pattern discovery, communicating insights to stakeholders, comparing distributions and relationships, or presenting findings in reports and dashboards.
 ---
 
 # Data Visualization

--- a/skills/database-backup-restore/SKILL.md
+++ b/skills/database-backup-restore/SKILL.md
@@ -66,13 +66,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Test restore procedures regularly — an untested backup is not a backup
+- Store backups in a separate region or account from the primary database
+- Use `pg_dump -Fc` (custom format) or `pg_basebackup` for large databases to enable parallel restore
+- Define and document RTO (Recovery Time Objective) and RPO (Recovery Point Objective) targets
+- Encrypt backups at rest and in transit, and restrict access with IAM or OS-level permissions
+- Automate backup schedules with cron or a managed service and monitor for failures
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Keep backups only on the same disk or server as the database
+- Skip verifying backup integrity — periodically restore to a test instance and validate data
+- Store database credentials in plain text inside backup scripts
+- Rely solely on full backups for large databases; combine with incremental/WAL archiving to meet RPO

--- a/skills/database-indexing-strategy/SKILL.md
+++ b/skills/database-indexing-strategy/SKILL.md
@@ -58,13 +58,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Use composite indexes with columns ordered by selectivity (most selective first)
+- Prefer partial indexes to reduce index size when queries filter on a known subset
+- Run EXPLAIN ANALYZE before and after adding indexes to verify they are used
+- Use CONCURRENTLY for index creation on production tables to avoid locking
+- Match index type to access pattern: B-tree for ranges, GIN for full-text/JSONB, BRIN for time-series
+- Monitor index usage via pg_stat_user_indexes and drop unused indexes regularly
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Index every column blindly — each index adds write overhead and storage cost
+- Create redundant indexes that are left-prefixes of existing composite indexes
+- Use indexes on low-cardinality columns (e.g., boolean flags) without a partial index filter
+- Forget to ANALYZE tables after bulk data loads so the planner has current statistics

--- a/skills/database-migration-management/SKILL.md
+++ b/skills/database-migration-management/SKILL.md
@@ -79,13 +79,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Write every migration with a matching rollback (down) script tested before deploying
+- Use non-locking operations (e.g., CREATE INDEX CONCURRENTLY, ADD COLUMN without DEFAULT on older PG)
+- Deploy schema changes separately from data backfills to keep transactions short
+- Record checksums for each migration file to detect accidental modifications
+- Test migrations against a production-size dataset copy, not just an empty schema
+- Add column with NULL first, backfill, then add NOT NULL constraint in a separate migration
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Run destructive DDL (DROP COLUMN, DROP TABLE) without a verified backup and rollback plan
+- Combine multiple unrelated schema changes in a single migration file
+- Rename columns in-place on high-traffic tables — use an expand-contract pattern instead
+- Assume migrations that pass on an empty database will succeed on production data

--- a/skills/database-monitoring/SKILL.md
+++ b/skills/database-monitoring/SKILL.md
@@ -80,13 +80,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Establish performance baselines during normal traffic before setting alert thresholds
+- Monitor connection pool utilization and idle-in-transaction sessions continuously
+- Track replication lag, WAL growth, and disk I/O alongside query-level metrics
+- Set up alerts for table bloat, long-running transactions, and lock wait times
+- Use pg_stat_statements or Performance Schema to identify top queries by total time
+- Retain historical metrics for capacity planning and trend analysis
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Set alert thresholds so low they cause alert fatigue — tune for actionable signals only
+- Monitor only CPU and memory while ignoring disk IOPS and query plan regressions
+- Query system catalogs (pg_stat_activity, information_schema) at high frequency on production without rate-limiting
+- Rely solely on application-level latency without correlating to database-level wait events

--- a/skills/database-performance-debugging/SKILL.md
+++ b/skills/database-performance-debugging/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: database-performance-debugging
 description: >
-  Debug database performance issues through query analysis, index optimization,
+  Debug database performance issues through query analysis, index optimization,.
+  Use when slow application response times, high database cpu, slow queries identified, or performance regression.
   and execution plan review. Identify and fix slow queries.
 ---
 
@@ -75,13 +76,15 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Start with EXPLAIN (ANALYZE, BUFFERS) to compare estimated vs actual rows and identify seq scans
+- Check pg_stat_statements or slow query log for top offenders by total execution time, not just single-call latency
+- Correlate query regressions with recent schema changes, data growth, or autovacuum activity
+- Profile under realistic load — single-query EXPLAIN misses contention and lock-wait issues
+- Look at actual buffer hits vs disk reads to distinguish CPU-bound from I/O-bound queries
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Optimize queries in isolation without considering how they behave under concurrent load
+- Add indexes as a reflex without confirming the planner will use them (check with EXPLAIN)
+- Ignore table bloat and dead tuples — they cause full-table scans even with valid indexes
+- Tune database parameters (work_mem, shared_buffers) without measuring the effect with benchmarks

--- a/skills/database-query-optimization/SKILL.md
+++ b/skills/database-query-optimization/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: database-query-optimization
 description: >
-  Improve database query performance through indexing, query optimization, and
+  Improve database query performance through indexing, query optimization, and.
+  Use when slow response times, high database cpu usage, performance regression, or new feature deployment.
   execution plan analysis. Reduce response times and database load.
 ---
 
@@ -69,13 +70,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Rewrite SELECT * to select only the columns needed — reduces I/O and enables index-only scans
+- Use EXPLAIN ANALYZE to verify index usage and check for unexpected seq scans or sort spills
+- Push filtering into WHERE clauses and JOINs rather than filtering in application code
+- Batch bulk operations (INSERT, UPDATE) to reduce round-trips and lock duration
+- Use CTEs or subqueries strategically — in PostgreSQL 12+, CTEs are inlined unless marked MATERIALIZED
+- Add covering indexes for frequently run queries to enable index-only scans
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Use OR across different columns in WHERE clauses without rewriting as UNION ALL
+- Wrap indexed columns in functions (e.g., WHERE LOWER(email) = ...) without a matching expression index
+- Use OFFSET for deep pagination — use keyset (cursor-based) pagination instead
+- Rely on query plan caching without periodically re-checking plans after significant data changes

--- a/skills/database-schema-design/SKILL.md
+++ b/skills/database-schema-design/SKILL.md
@@ -73,13 +73,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Normalize to 3NF by default, then selectively denormalize with clear justification for read performance
+- Define explicit foreign keys with appropriate ON DELETE/ON UPDATE actions for every relationship
+- Use the narrowest appropriate data type (e.g., INTEGER vs BIGINT, VARCHAR(n) vs TEXT where limits are known)
+- Add NOT NULL constraints by default and only allow NULL when the business domain requires it
+- Include created_at and updated_at timestamps on all mutable tables for auditability
+- Use UUID or BIGSERIAL primary keys consistently — avoid natural keys that may change
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Store comma-separated values or JSON arrays when a proper join table should be used
+- Create tables without primary keys or with composite natural keys that complicate joins
+- Skip CHECK constraints for domain-specific validation (e.g., positive prices, valid status enums)
+- Design schemas without considering the query patterns — schema and index strategy go together

--- a/skills/database-sharding/SKILL.md
+++ b/skills/database-sharding/SKILL.md
@@ -76,13 +76,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Choose a shard key with high cardinality and even distribution to prevent hotspots
+- Use consistent hashing to minimize data movement when adding or removing shards
+- Design the schema so the most common queries can be served from a single shard
+- Plan a rebalancing strategy before you need it — shard splits are painful under load
+- Keep a shard routing directory or mapping table and version it with every topology change
+- Test cross-shard queries and transactions explicitly — they are the primary source of latency
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Shard prematurely — exhaust vertical scaling and read replicas before adding sharding complexity
+- Use a shard key that changes over time (e.g., status fields) or has low cardinality (e.g., country code)
+- Assume auto-increment IDs are globally unique across shards without a distributed ID strategy
+- Ignore the operational cost: backups, migrations, and schema changes multiply by shard count

--- a/skills/dependency-tracking/SKILL.md
+++ b/skills/dependency-tracking/SKILL.md
@@ -2,7 +2,8 @@
 name: dependency-tracking
 description: >
   Map, track, and manage project dependencies across teams, systems, and
-  organizations. Identify critical path items and prevent blocking issues
+  organizations. Identify critical path items and prevent blocking issues.
+  Use when multi-team projects and programs, complex technical integrations, cross-organizational initiatives, or identifying critical path items.
   through proactive dependency management.
 ---
 

--- a/skills/deployment-automation/SKILL.md
+++ b/skills/deployment-automation/SKILL.md
@@ -2,6 +2,7 @@
 name: deployment-automation
 description: >
   Automate deployments across environments using Helm, Terraform, and ArgoCD.
+  Use when continuous deployment to kubernetes, infrastructure as code deployment, multi-environment promotion, or blue-green deployment strategies.
   Implement blue-green deployments, canary releases, and rollback strategies.
 ---
 

--- a/skills/design-handoff/SKILL.md
+++ b/skills/design-handoff/SKILL.md
@@ -2,7 +2,8 @@
 name: design-handoff
 description: >
   Prepare designs for development handoff. Document specifications,
-  interactions, and assets to enable efficient development and maintain design
+  interactions, and assets to enable efficient development and maintain design.
+  Use when before development starts, feature completion in design, component library updates, or design system changes.
   quality.
 ---
 

--- a/skills/design-system-creation/SKILL.md
+++ b/skills/design-system-creation/SKILL.md
@@ -2,7 +2,8 @@
 name: design-system-creation
 description: >
   Build comprehensive design systems with components, patterns, and guidelines.
-  Enable consistent design, faster development, and better collaboration across
+  Enable consistent design, faster development, and better collaboration across.
+  Use when multiple product interfaces or teams, scaling design consistency, reducing redundant component development, or improving design-to-dev handoff.
   teams.
 ---
 

--- a/skills/dimensionality-reduction/SKILL.md
+++ b/skills/dimensionality-reduction/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Dimensionality Reduction
-description: Reduce feature dimensionality using PCA, t-SNE, and feature selection for feature reduction, visualization, and computational efficiency
+name: dimensionality-reduction
+description: >
+  Reduce feature dimensionality using PCA, t-SNE, and feature selection for feature reduction, visualization, and computational efficiency.
+  Use when high-dimensional datasets with many features, visualizing complex datasets in 2d or 3d, reducing computational complexity and training time, or removing redundant or highly correlated features.
 ---
 
 # Dimensionality Reduction

--- a/skills/disaster-recovery-testing/SKILL.md
+++ b/skills/disaster-recovery-testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: disaster-recovery-testing
 description: >
-  Execute comprehensive disaster recovery tests, validate recovery procedures,
+  Execute comprehensive disaster recovery tests, validate recovery procedures,.
+  Use when annual dr exercises, infrastructure changes, new service deployments, or compliance requirements.
   and document lessons learned from DR exercises.
 ---
 

--- a/skills/dns-management/SKILL.md
+++ b/skills/dns-management/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: dns-management
 description: >
-  Manage DNS records, routing policies, and failover configurations for high
+  Manage DNS records, routing policies, and failover configurations for high.
+  Use when domain management and routing, failover and disaster recovery, geographic load balancing, or multi-region deployments.
   availability and disaster recovery.
 ---
 

--- a/skills/e2e-testing-automation/SKILL.md
+++ b/skills/e2e-testing-automation/SKILL.md
@@ -2,7 +2,8 @@
 name: e2e-testing-automation
 description: >
   Build end-to-end automated tests that simulate real user interactions across
-  the full application stack. Use for E2E test, Selenium, Cypress, Playwright,
+  the full application stack. Use for E2E test, Selenium, Cypress, Playwright,.
+  Use when testing critical user journeys (signup, checkout, login), validating multi-step workflows, testing across different browsers and devices, or regression testing for ui changes.
   browser automation, and user journey testing.
 ---
 

--- a/skills/exploratory-data-analysis/SKILL.md
+++ b/skills/exploratory-data-analysis/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Exploratory Data Analysis
-description: Discover patterns, distributions, and relationships in data through visualization, summary statistics, and hypothesis generation for exploratory data analysis, data profiling, and initial insights
+name: exploratory-data-analysis
+description: >
+  Discover patterns, distributions, and relationships in data through visualization, summary statistics, and hypothesis generation for exploratory data analysis, data profiling, and initial insights.
+  Use when starting a new dataset analysis, understanding data before modeling, identifying data quality issues, or generating hypotheses for testing.
 ---
 
 # Exploratory Data Analysis (EDA)

--- a/skills/feature-engineering/SKILL.md
+++ b/skills/feature-engineering/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Feature Engineering
-description: Create and transform features using encoding, scaling, polynomial features, and domain-specific transformations for improved model performance and interpretability
+name: feature-engineering
+description: >
+  Create and transform features using encoding, scaling, polynomial features, and domain-specific transformations for improved model performance and interpretability.
+  Use when when you need to improve model performance beyond using raw features, when dealing with categorical variables that need encoding for ml algorithms, when features have different scales and require normalization, or when creating domain-specific features based on business knowledge.
 ---
 
 # Feature Engineering

--- a/skills/flutter-development/SKILL.md
+++ b/skills/flutter-development/SKILL.md
@@ -2,7 +2,8 @@
 name: flutter-development
 description: >
   Build beautiful cross-platform mobile apps with Flutter and Dart. Covers
-  widgets, state management with Provider/BLoC, navigation, API integration, and
+  widgets, state management with Provider/BLoC, navigation, API integration, and.
+  Use when building ios and android apps with native performance, designing custom uis with flutter's widget system, implementing complex animations and visual effects, or rapid app development with hot reload.
   material design.
 ---
 

--- a/skills/form-validation/SKILL.md
+++ b/skills/form-validation/SKILL.md
@@ -77,13 +77,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Validate on both client and server — client-side validation is a UX convenience, not a security boundary
+- Show inline error messages next to the field that failed, not just a summary at the top
+- Use schema-based validation (Zod, Yup) to share validation rules between frontend and backend
+- Debounce async validators (e.g., username availability checks) to avoid excessive API calls
+- Associate error messages with fields via aria-describedby for screen reader accessibility
+- Preserve user input on validation failure — never clear the form on error
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Validate on blur alone — combine with on-submit validation so users see all errors before submitting
+- Write custom regex for emails — use the validation library's built-in email validator or type="email"
+- Block form submission silently — always surface a visible, specific error message
+- Rely on HTML5 required/pattern attributes as the sole validation — they vary across browsers

--- a/skills/frontend-accessibility/SKILL.md
+++ b/skills/frontend-accessibility/SKILL.md
@@ -76,13 +76,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Use semantic HTML elements (nav, main, article, button) before reaching for ARIA roles
+- Ensure all interactive elements are keyboard-operable with visible focus indicators
+- Maintain a minimum 4.5:1 color contrast ratio for normal text (WCAG AA)
+- Provide text alternatives for all non-decorative images and meaningful icons
+- Test with a screen reader (VoiceOver, NVDA) and keyboard-only navigation on every major feature
+- Use aria-live regions to announce dynamic content changes to assistive technology
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Use div or span with onClick handlers instead of button or anchor elements
+- Remove or hide the browser's default focus outline without providing a custom visible focus style
+- Rely on color alone to convey meaning (e.g., red for error) — add text or icons as well
+- Add aria-label or aria-describedby that duplicates already-visible text — it creates redundant announcements

--- a/skills/frontend-routing/SKILL.md
+++ b/skills/frontend-routing/SKILL.md
@@ -77,13 +77,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Lazy-load route components with React.lazy or dynamic imports to reduce initial bundle size
+- Implement route-level error boundaries so a crash in one route doesn't break the whole app
+- Use a centralized route config (array or object) rather than scattering Route declarations
+- Protect authenticated routes with a guard component that redirects before rendering
+- Preserve scroll position on back navigation and reset it on forward navigation
+- Reflect meaningful application state in the URL so users can bookmark and share deep links
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Store transient UI state (modals, toasts) in the URL — route params are for navigable state only
+- Use nested wildcard routes without a catch-all 404 page at the end
+- Fetch data inside the route component without a loading state — use loader functions or Suspense
+- Hard-code route paths as strings throughout the app — define them as constants in one place

--- a/skills/frontend-state-management/SKILL.md
+++ b/skills/frontend-state-management/SKILL.md
@@ -75,13 +75,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Co-locate state as close to the consuming component as possible — lift only when shared
+- Separate server-cache state (React Query, SWR) from client UI state (Zustand, Redux)
+- Use selectors to derive computed values rather than storing redundant data in the store
+- Keep reducers and actions pure — side effects belong in middleware or effect hooks
+- Normalize nested data structures to avoid deep cloning and stale reference bugs
+- Use TypeScript to type your store slices, actions, and selectors for compile-time safety
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Put every piece of state in a global store — form input, hover state, and animation state should stay local
+- Mutate state directly — always produce a new reference (Redux Toolkit's Immer handles this, raw Redux does not)
+- Use Context API for frequently-updating values — it re-renders all consumers on every change
+- Create actions that do too much — keep them granular so time-travel debugging stays useful

--- a/skills/frontend-testing/SKILL.md
+++ b/skills/frontend-testing/SKILL.md
@@ -78,13 +78,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Query elements by accessible roles and labels (`getByRole`, `getByLabelText`) rather than CSS selectors or test IDs
+- Test user-visible behavior and outcomes, not internal component state or implementation details
+- Use `waitFor` and `findBy` queries for async UI updates instead of arbitrary timeouts
+- Isolate unit tests with mocked API responses and test integration paths separately with MSW or similar
+- Write E2E tests for critical user journeys (login, checkout, form submission) that cover the full stack
+- Keep tests deterministic by resetting state between runs and avoiding shared mutable fixtures
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Snapshot-test large component trees — they produce brittle, low-signal diffs that get blindly updated
+- Couple tests to DOM structure (e.g., `div > span:nth-child(2)`) — refactors will break them without any real regression
+- Mix unit and E2E concerns in the same test file; keep the test pyramid layers distinct
+- Fire events directly on DOM nodes when `userEvent` from Testing Library provides more realistic interaction simulation

--- a/skills/funnel-analysis/SKILL.md
+++ b/skills/funnel-analysis/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Funnel Analysis
-description: Analyze user conversion funnels, identify drop-off points, and optimize conversion rates for conversion optimization and user flow analysis
+name: funnel-analysis
+description: >
+  Analyze user conversion funnels, identify drop-off points, and optimize conversion rates for conversion optimization and user flow analysis.
+  Use when when optimizing user conversion paths and improving conversion rates, when identifying bottlenecks and drop-off points in user flows, when comparing performance across different segments or traffic sources, or when measuring product feature adoption or onboarding effectiveness.
 ---
 
 # Funnel Analysis

--- a/skills/gap-analysis/SKILL.md
+++ b/skills/gap-analysis/SKILL.md
@@ -2,7 +2,8 @@
 name: gap-analysis
 description: >
   Identify differences between current state and desired future state. Analyze
-  gaps in capabilities, processes, skills, and technology to plan improvements
+  gaps in capabilities, processes, skills, and technology to plan improvements.
+  Use when strategic planning and goal setting, technology modernization assessment, process improvement initiatives, or skills and training planning.
   and investments.
 ---
 

--- a/skills/gcp-cloud-functions/SKILL.md
+++ b/skills/gcp-cloud-functions/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: gcp-cloud-functions
 description: >
-  Deploy serverless functions on Google Cloud Platform with triggers, IAM roles,
+  Deploy serverless functions on Google Cloud Platform with triggers, IAM roles,.
+  Use when http apis and webhooks, pub/sub message processing, storage bucket events, or firestore database triggers.
   environment variables, and monitoring. Use for event-driven computing on GCP.
 ---
 

--- a/skills/gcp-cloud-run/SKILL.md
+++ b/skills/gcp-cloud-run/SKILL.md
@@ -2,7 +2,8 @@
 name: gcp-cloud-run
 description: >
   Deploy containerized applications on Google Cloud Run with automatic scaling,
-  traffic management, and service mesh integration. Use for container-based
+  traffic management, and service mesh integration. Use for container-based.
+  Use when microservices and apis, web applications and backends, batch processing jobs, or long-running background workers.
   serverless computing.
 ---
 

--- a/skills/git-hooks-setup/SKILL.md
+++ b/skills/git-hooks-setup/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: git-hooks-setup
 description: >
-  Implement Git hooks using Husky, pre-commit, and custom scripts. Enforce code
+  Implement Git hooks using Husky, pre-commit, and custom scripts. Enforce code.
+  Use when pre-commit code quality checks, commit message validation, preventing secrets in commits, or running tests before push.
   quality, linting, and testing before commits and pushes.
 ---
 

--- a/skills/git-workflow-strategy/SKILL.md
+++ b/skills/git-workflow-strategy/SKILL.md
@@ -2,7 +2,8 @@
 name: git-workflow-strategy
 description: >
   Master Git workflows including GitFlow, GitHub Flow, Trunk-Based Development.
-  Configure branches, merge strategies, and collaboration patterns for team
+  Configure branches, merge strategies, and collaboration patterns for team.
+  Use when team collaboration setup, release management, feature development coordination, or hotfix procedures.
   environments.
 ---
 

--- a/skills/github-actions-workflow/SKILL.md
+++ b/skills/github-actions-workflow/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: github-actions-workflow
 description: >
-  Build comprehensive GitHub Actions workflows for CI/CD, testing, security, and
+  Build comprehensive GitHub Actions workflows for CI/CD, testing, security, and.
+  Use when continuous integration and testing, build automation, security scanning and analysis, or dependency updates.
   deployment. Master workflows, jobs, steps, and conditional execution.
 ---
 

--- a/skills/gitlab-cicd-pipeline/SKILL.md
+++ b/skills/gitlab-cicd-pipeline/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: gitlab-cicd-pipeline
 description: >
-  Design and implement GitLab CI/CD pipelines with stages, jobs, artifacts, and
+  Design and implement GitLab CI/CD pipelines with stages, jobs, artifacts, and.
+  Use when gitlab repository ci/cd setup, multi-stage build pipelines, docker registry integration, or kubernetes deployment.
   caching. Configure runners, Docker integration, and deployment strategies.
 ---
 

--- a/skills/graceful-shutdown/SKILL.md
+++ b/skills/graceful-shutdown/SKILL.md
@@ -3,7 +3,8 @@ name: graceful-shutdown
 description: >
   Implement graceful shutdown procedures to handle SIGTERM signals, drain
   connections, complete in-flight requests, and clean up resources properly. Use
-  when deploying containerized applications, handling server restarts, or
+  when deploying containerized applications, handling server restarts, or.
+  Use when kubernetes/docker deployments, rolling updates and deployments, server restarts, or load balancer drain periods.
   ensuring zero-downtime deployments.
 ---
 

--- a/skills/image-optimization/SKILL.md
+++ b/skills/image-optimization/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: image-optimization
 description: >
-  Optimize images for web to reduce file size without sacrificing quality. Use
+  Optimize images for web to reduce file size without sacrificing quality. Use.
+  Use when website optimization, responsive image implementation, performance improvement, or mobile experience enhancement.
   compression, modern formats, and responsive techniques for faster loading.
 ---
 
@@ -75,13 +76,15 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Serve WebP/AVIF with `<picture>` fallbacks to JPEG/PNG for older browsers
+- Use responsive `srcset` and `sizes` attributes so devices download only the resolution they need
+- Lazy-load below-the-fold images with `loading="lazy"` or Intersection Observer
+- Automate compression in the build pipeline (e.g., sharp, imagemin) so optimized assets are never skipped
+- Set explicit `width` and `height` attributes or use CSS `aspect-ratio` to prevent Cumulative Layout Shift
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Serve uncompressed originals directly from a CMS or upload directory
+- Use PNG for photographic content — JPEG or WebP will be a fraction of the size at comparable quality
+- Resize images in CSS while delivering full-resolution files over the network
+- Strip all EXIF metadata blindly — preserve copyright and orientation data when legally required

--- a/skills/information-architecture/SKILL.md
+++ b/skills/information-architecture/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: information-architecture
 description: >
-  Organize and structure information for clarity and discoverability. Design
+  Organize and structure information for clarity and discoverability. Design.
+  Use when website or app redesign, large information spaces (documentation, e-commerce), navigation structure planning, or taxonomy and categorization.
   navigation systems, hierarchies, and mental models that match user needs.
 ---
 

--- a/skills/infrastructure-cost-optimization/SKILL.md
+++ b/skills/infrastructure-cost-optimization/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: infrastructure-cost-optimization
 description: >
-  Optimize cloud infrastructure costs through resource rightsizing, reserved
+  Optimize cloud infrastructure costs through resource rightsizing, reserved.
+  Use when cloud cost reduction, budget management and tracking, resource utilization optimization, or multi-environment cost allocation.
   instances, spot instances, and waste reduction strategies.
 ---
 
@@ -76,13 +77,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Rightsize instances based on actual utilization data (CPU, memory, network) over at least 14 days before committing to reservations
+- Tag every resource with cost-allocation tags (team, environment, service) to enable accurate chargeback and waste detection
+- Use Spot/Preemptible instances for stateless, fault-tolerant workloads and batch jobs
+- Schedule non-production environments to shut down outside business hours automatically
+- Review Reserved Instance and Savings Plan coverage monthly and adjust for changing workloads
+- Set budget alerts at 50%, 80%, and 100% thresholds with automated notifications to the responsible team
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Purchase Reserved Instances based on peak demand — buy for steady-state baseline and cover spikes with on-demand or Spot
+- Leave unattached EBS volumes, idle load balancers, or orphaned snapshots running unreviewed
+- Assume last month's cost breakdown still applies — workloads drift and new services appear
+- Optimize cost at the expense of reliability without explicit stakeholder sign-off on the trade-off

--- a/skills/infrastructure-monitoring/SKILL.md
+++ b/skills/infrastructure-monitoring/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: infrastructure-monitoring
 description: >
-  Set up comprehensive infrastructure monitoring with Prometheus, Grafana, and
+  Set up comprehensive infrastructure monitoring with Prometheus, Grafana, and.
+  Use when real-time performance monitoring, capacity planning and trends, incident detection and alerting, or service health tracking.
   alerting systems for metrics, health checks, and performance tracking.
 ---
 
@@ -79,13 +80,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Define alerts on symptoms (error rate, latency, saturation) rather than causes — let dashboards show the cause
+- Use the USE method (Utilization, Saturation, Errors) for infrastructure and RED method (Rate, Errors, Duration) for services
+- Set retention policies that balance cost with the need for historical trend analysis and capacity planning
+- Include runbook links in every alert so on-call responders know the immediate next steps
+- Monitor the monitoring stack itself — a silent alerting pipeline is worse than no alerting at all
+- Label metrics consistently with service, environment, and instance dimensions for easy filtering
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Alert on every metric threshold — this creates alert fatigue and trains teams to ignore pages
+- Set static thresholds without accounting for normal variance (use anomaly detection or dynamic thresholds where possible)
+- Rely solely on pull-based scraping for ephemeral workloads — use push gateways or service mesh telemetry for short-lived jobs
+- Store high-cardinality labels (user IDs, request IDs) in Prometheus metrics — use logs or traces for that data

--- a/skills/integration-testing/SKILL.md
+++ b/skills/integration-testing/SKILL.md
@@ -3,7 +3,8 @@ name: integration-testing
 description: >
   Design and implement integration tests that verify component interactions, API
   endpoints, database operations, and external service communication. Use for
-  integration test, API test, end-to-end component testing, and service layer
+  integration test, API test, end-to-end component testing, and service layer.
+  Use when testing api endpoints with real database connections, verifying service-to-service communication, validating data flow across multiple layers, or testing repository/dao layer with actual databases.
   validation.
 ---
 

--- a/skills/interaction-design/SKILL.md
+++ b/skills/interaction-design/SKILL.md
@@ -2,7 +2,8 @@
 name: interaction-design
 description: >
   Design meaningful interactions and microinteractions. Create delightful user
-  experiences through thoughtful animation, feedback, and responsive interface
+  experiences through thoughtful animation, feedback, and responsive interface.
+  Use when designing user flows and touchpoints, creating animations and transitions, defining error and loading states, or building microinteractions.
   design.
 ---
 

--- a/skills/intermittent-issue-debugging/SKILL.md
+++ b/skills/intermittent-issue-debugging/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: intermittent-issue-debugging
 description: >
-  Debug issues that occur sporadically and are hard to reproduce. Use monitoring
+  Debug issues that occur sporadically and are hard to reproduce. Use monitoring.
+  Use when sporadic errors in logs, users report occasional issues, flaky tests, or race conditions suspected.
   and systematic investigation to identify root causes of flaky behavior.
 ---
 
@@ -76,13 +77,15 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Attach correlation IDs to every request so you can trace a single occurrence across services and logs
+- Increase logging verbosity temporarily around the suspected area and capture timestamps, thread IDs, and resource state
+- Reproduce timing-dependent bugs with stress tests, chaos engineering, or artificially injected delays
+- Use statistical analysis on occurrence patterns (time of day, load level, specific inputs) to narrow the search space
+- Write a deterministic regression test that reliably triggers the root cause before declaring the fix complete
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Dismiss a sporadic failure as a "fluke" without investigating — intermittent issues tend to worsen under load
+- Change multiple variables at once when testing a hypothesis; isolate one factor at a time
+- Remove enhanced logging immediately after a fix — keep it long enough to confirm the issue is truly resolved in production
+- Assume the issue is environment-specific without checking for shared dependencies like DNS, NTP, or connection pool limits

--- a/skills/internationalization-i18n/SKILL.md
+++ b/skills/internationalization-i18n/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Implement internationalization (i18n) and localization including message
   extraction, translation catalogs, pluralization rules, date/time/number
   formatting, RTL language support, and i18n libraries like i18next and gettext.
+  Use when building multi-language applications, supporting international users, implementing language switching, or formatting dates, times, and numbers for different locales.
   Use for multi-language, translation, or localization needs.
 ---
 

--- a/skills/ios-swift-development/SKILL.md
+++ b/skills/ios-swift-development/SKILL.md
@@ -2,7 +2,8 @@
 name: ios-swift-development
 description: >
   Develop native iOS apps with Swift. Covers MVVM architecture, SwiftUI,
-  URLSession for networking, Combine for reactive programming, and Core Data
+  URLSession for networking, Combine for reactive programming, and Core Data.
+  Use when creating native ios applications with optimal performance, leveraging ios-specific features and apis, building apps that require tight hardware integration, or using swiftui for declarative ui development.
   persistence.
 ---
 

--- a/skills/jenkins-pipeline/SKILL.md
+++ b/skills/jenkins-pipeline/SKILL.md
@@ -2,7 +2,8 @@
 name: jenkins-pipeline
 description: >
   Build Jenkins declarative and scripted pipelines with stages, agents,
-  parameters, and plugins. Implement multi-branch pipelines and deployment
+  parameters, and plugins. Implement multi-branch pipelines and deployment.
+  Use when enterprise ci/cd infrastructure, complex multi-stage builds, on-premise deployment automation, or parameterized builds.
   automation.
 ---
 

--- a/skills/kpi-dashboard-design/SKILL.md
+++ b/skills/kpi-dashboard-design/SKILL.md
@@ -2,7 +2,8 @@
 name: kpi-dashboard-design
 description: >
   Design and build dashboards that track key performance indicators. Select
-  relevant metrics, visualize data effectively, and communicate insights to
+  relevant metrics, visualize data effectively, and communicate insights to.
+  Use when creating performance measurement systems, leadership reporting and visibility, operational monitoring, or project progress tracking.
   stakeholders.
 ---
 

--- a/skills/kubernetes-deployment/SKILL.md
+++ b/skills/kubernetes-deployment/SKILL.md
@@ -2,7 +2,8 @@
 name: kubernetes-deployment
 description: >
   Deploy, manage, and scale containerized applications on Kubernetes clusters
-  with best practices for production workloads, resource management, and rolling
+  with best practices for production workloads, resource management, and rolling.
+  Use when container orchestration and management, multi-environment deployments (dev, staging, prod), auto-scaling microservices, or rolling updates and blue-green deployments.
   updates.
 ---
 

--- a/skills/load-balancer-setup/SKILL.md
+++ b/skills/load-balancer-setup/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: load-balancer-setup
 description: >
-  Configure and deploy load balancers (HAProxy, AWS ELB/ALB/NLB) for
+  Configure and deploy load balancers (HAProxy, AWS ELB/ALB/NLB) for.
+  Use when multi-server traffic distribution, high availability and failover, session persistence and sticky sessions, or health checking and auto-recovery.
   distributing traffic, session management, and high availability.
 ---
 

--- a/skills/log-aggregation/SKILL.md
+++ b/skills/log-aggregation/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: log-aggregation
 description: >
-  Implement centralized logging with ELK Stack, Loki, or Splunk for log
+  Implement centralized logging with ELK Stack, Loki, or Splunk for log.
+  Use when centralized log collection, distributed system debugging, compliance and audit logging, or security event monitoring.
   collection, parsing, storage, and analysis across infrastructure.
 ---
 

--- a/skills/log-analysis/SKILL.md
+++ b/skills/log-analysis/SKILL.md
@@ -2,7 +2,8 @@
 name: log-analysis
 description: >
   Analyze application and system logs to identify errors, patterns, and root
-  causes. Use log aggregation tools and structured logging for effective
+  causes. Use log aggregation tools and structured logging for effective.
+  Use when troubleshooting errors, performance investigation, security incident analysis, or auditing user actions.
   debugging.
 ---
 
@@ -76,13 +77,15 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Use structured logging (JSON) with consistent fields: timestamp, level, service, trace_id, and message
+- Include contextual data (user ID, request ID, duration) in every log entry so queries don't require cross-referencing
+- Set appropriate log levels — DEBUG for development, INFO for normal operations, WARN/ERROR for actionable conditions
+- Centralize logs in an aggregation platform (ELK, Loki, Datadog) with index lifecycle policies to manage storage costs
+- Define saved queries and dashboards for common investigations (top errors, slow endpoints, auth failures)
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Log sensitive data (passwords, tokens, PII) — redact or mask before writing to any log sink
+- Use unstructured string interpolation (`"User " + id + " failed"`) — it makes parsing and filtering nearly impossible at scale
+- Set everything to DEBUG in production — the noise will bury real signals and inflate storage costs
+- Rely solely on `grep` against raw log files when your system produces more than a few GB per day

--- a/skills/logging-best-practices/SKILL.md
+++ b/skills/logging-best-practices/SKILL.md
@@ -2,7 +2,8 @@
 name: logging-best-practices
 description: >
   Implement structured logging with JSON formats, log levels (DEBUG, INFO, WARN,
-  ERROR), contextual logging, PII handling, and centralized logging. Use for
+  ERROR), contextual logging, PII handling, and centralized logging. Use for.
+  Use when setting up application logging infrastructure, implementing structured logging, configuring log levels for different environments, or managing sensitive data in logs.
   logging, observability, log levels, structured logs, or debugging.
 ---
 

--- a/skills/memory-optimization/SKILL.md
+++ b/skills/memory-optimization/SKILL.md
@@ -2,7 +2,8 @@
 name: memory-optimization
 description: >
   Profile and optimize application memory usage. Identify memory leaks, reduce
-  memory footprint, and improve efficiency for better performance and
+  memory footprint, and improve efficiency for better performance and.
+  Use when high memory usage, memory leaks suspected, slow performance, or out of memory crashes.
   reliability.
 ---
 
@@ -76,13 +77,15 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Profile with heap snapshots before and after suspected operations to measure actual retained memory, not just allocations
+- Use WeakRef and WeakMap for caches and observers that should not prevent garbage collection
+- Pool and reuse expensive objects (buffers, database connections) instead of allocating and discarding per request
+- Set memory budgets in CI (e.g., `--max-old-space-size` assertions) to catch regressions before they reach production
+- Clean up event listeners, timers, and subscriptions in component teardown or `finally` blocks
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Load entire datasets into memory when streaming or pagination would keep the working set bounded
+- Hold references to detached DOM nodes — this is the most common source of browser memory leaks
+- Rely on the garbage collector to compensate for unbounded growth in caches or queues — set explicit eviction policies
+- Optimize memory in micro-benchmarks without verifying the improvement under realistic, sustained load

--- a/skills/ml-model-explanation/SKILL.md
+++ b/skills/ml-model-explanation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ML Model Explanation
+name: ml-model-explanation
 description: Interpret machine learning models using SHAP, LIME, feature importance, partial dependence, and attention visualization for explainability
 ---
 

--- a/skills/ml-model-training/SKILL.md
+++ b/skills/ml-model-training/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ML Model Training
+name: ml-model-training
 description: Build and train machine learning models using scikit-learn, PyTorch, and TensorFlow for classification, regression, and clustering tasks
 ---
 

--- a/skills/ml-pipeline-automation/SKILL.md
+++ b/skills/ml-pipeline-automation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ML Pipeline Automation
+name: ml-pipeline-automation
 description: Build end-to-end ML pipelines with automated data processing, training, validation, and deployment using Airflow, Kubeflow, and Jenkins
 ---
 

--- a/skills/mobile-app-debugging/SKILL.md
+++ b/skills/mobile-app-debugging/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: mobile-app-debugging
 description: >
-  Debug issues specific to mobile applications including platform-specific
+  Debug issues specific to mobile applications including platform-specific.
+  Use when app crashes on mobile, performance issues on device, platform-specific bugs, or network connectivity issues.
   problems, device constraints, and connectivity issues.
 ---
 
@@ -75,13 +76,15 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Test on real devices across OS versions — simulators miss GPU, memory, and thermal throttling behavior
+- Use platform-specific profilers (Xcode Instruments, Android Studio Profiler) to measure CPU, memory, and energy impact
+- Reproduce crashes by symbolizing crash logs and matching to the exact build version and device model
+- Test under degraded network conditions (airplane mode toggle, 3G throttling, high latency) to catch connectivity edge cases
+- Check for retain cycles (iOS) and Activity/Context leaks (Android) as a routine part of debugging memory issues
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Assume behavior on one OS version applies to all — API deprecations and permission changes break across versions
+- Block the main/UI thread with synchronous network calls, heavy computation, or large database reads
+- Ignore low-memory warnings (`didReceiveMemoryWarning`, `onTrimMemory`) — the OS will terminate unresponsive apps
+- Test only on high-end devices — budget devices with limited RAM and slower CPUs expose real-world performance issues

--- a/skills/mobile-app-testing/SKILL.md
+++ b/skills/mobile-app-testing/SKILL.md
@@ -2,7 +2,8 @@
 name: mobile-app-testing
 description: >
   Comprehensive mobile app testing strategies for iOS and Android. Covers unit
-  tests, UI tests, integration tests, performance testing, and test automation
+  tests, UI tests, integration tests, performance testing, and test automation.
+  Use when creating reliable mobile applications with test coverage, automating ui testing across ios and android, performance testing and optimization, or integration testing with backend services.
   with Detox, Appium, and XCTest.
 ---
 

--- a/skills/mobile-first-design/SKILL.md
+++ b/skills/mobile-first-design/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: mobile-first-design
 description: >
-  Design for mobile devices first, then scale up to larger screens. Create
+  Design for mobile devices first, then scale up to larger screens. Create.
+  Use when web application design, responsive website creation, feature prioritization, or performance optimization.
   responsive interfaces that work seamlessly across all device sizes.
 ---
 

--- a/skills/mobile-offline-support/SKILL.md
+++ b/skills/mobile-offline-support/SKILL.md
@@ -2,7 +2,8 @@
 name: mobile-offline-support
 description: >
   Implement offline-first mobile apps with local storage, sync strategies, and
-  conflict resolution. Covers AsyncStorage, Realm, SQLite, and background sync
+  conflict resolution. Covers AsyncStorage, Realm, SQLite, and background sync.
+  Use when building apps that work without internet connection, implementing seamless sync when connectivity returns, handling data conflicts between device and server, or reducing server load with intelligent caching.
   patterns.
 ---
 

--- a/skills/mocking-stubbing/SKILL.md
+++ b/skills/mocking-stubbing/SKILL.md
@@ -2,7 +2,8 @@
 name: mocking-stubbing
 description: >
   Create and manage mocks, stubs, spies, and test doubles for isolating unit
-  tests from external dependencies. Use for mock, stub, spy, test double,
+  tests from external dependencies. Use for mock, stub, spy, test double,.
+  Use when isolating unit tests from external dependencies, testing code that depends on slow operations (db, network), simulating error conditions and edge cases, or verifying interactions between objects.
   Mockito, Jest mocks, and dependency isolation.
 ---
 

--- a/skills/model-deployment/SKILL.md
+++ b/skills/model-deployment/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Model Deployment
-description: Deploy machine learning models to production using Flask, FastAPI, Docker, cloud platforms (AWS, GCP, Azure), and model serving frameworks
+name: model-deployment
+description: >
+  Deploy machine learning models to production using Flask, FastAPI, Docker, cloud platforms (AWS, GCP, Azure), and model serving frameworks.
+  Use when when productionizing trained models for real-world inference and predictions, when building rest apis or web services for model serving, when scaling predictions to serve multiple users or applications, or when deploying models to cloud platforms, edge devices, or containers.
 ---
 
 # Model Deployment

--- a/skills/model-hyperparameter-tuning/SKILL.md
+++ b/skills/model-hyperparameter-tuning/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Model Hyperparameter Tuning
-description: Optimize hyperparameters using grid search, random search, Bayesian optimization, and automated ML frameworks like Optuna and Hyperopt
+name: model-hyperparameter-tuning
+description: >
+  Optimize hyperparameters using grid search, random search, Bayesian optimization, and automated ML frameworks like Optuna and Hyperopt.
+  Use when when optimizing model performance beyond baseline configurations, when comparing different parameter combinations systematically, when fine-tuning complex models with many hyperparameters, or when seeking the best trade-off between bias, variance, and training time.
 ---
 
 # Model Hyperparameter Tuning

--- a/skills/model-monitoring/SKILL.md
+++ b/skills/model-monitoring/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Model Monitoring
-description: Monitor model performance, detect data drift, concept drift, and anomalies in production using Prometheus, Grafana, and MLflow
+name: model-monitoring
+description: >
+  Monitor model performance, detect data drift, concept drift, and anomalies in production using Prometheus, Grafana, and MLflow.
+  Use when when models are deployed in production environments serving real users, when detecting data drift or concept drift in input features, when tracking model performance metrics over time, or when ensuring model reliability, accuracy, and operational health.
 ---
 
 # Model Monitoring

--- a/skills/monorepo-management/SKILL.md
+++ b/skills/monorepo-management/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: monorepo-management
 description: >
-  Manage monorepo architectures using Lerna, Turborepo, and Nx. Configure
+  Manage monorepo architectures using Lerna, Turborepo, and Nx. Configure.
+  Use when multi-package projects, shared libraries across services, microservices architecture, or plugin-based systems.
   workspaces, dependency versioning, and cross-package testing.
 ---
 

--- a/skills/multi-cloud-strategy/SKILL.md
+++ b/skills/multi-cloud-strategy/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: multi-cloud-strategy
 description: >
-  Design and implement multi-cloud strategies spanning AWS, Azure, and GCP with
+  Design and implement multi-cloud strategies spanning AWS, Azure, and GCP with.
+  Use when reducing vendor lock-in risk, optimizing costs across providers, geographic distribution requirements, or compliance with regional data laws.
   vendor lock-in avoidance, hybrid deployments, and federation.
 ---
 

--- a/skills/mutation-testing/SKILL.md
+++ b/skills/mutation-testing/SKILL.md
@@ -2,7 +2,8 @@
 name: mutation-testing
 description: >
   Evaluate test suite quality by introducing code mutations and verifying tests
-  catch them. Use for mutation testing, test quality, mutant detection, Stryker,
+  catch them. Use for mutation testing, test quality, mutant detection, Stryker,.
+  Use when evaluating test suite effectiveness, finding untested code paths, improving test quality metrics, or validating critical business logic is well-tested.
   PITest, and test effectiveness analysis.
 ---
 

--- a/skills/natural-language-processing/SKILL.md
+++ b/skills/natural-language-processing/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Natural Language Processing
-description: Build NLP applications using transformers library, BERT, GPT, text classification, named entity recognition, and sentiment analysis
+name: natural-language-processing
+description: >
+  Build NLP applications using transformers library, BERT, GPT, text classification, named entity recognition, and sentiment analysis.
+  Use when building text classification systems for sentiment analysis, topic categorization, or intent detection, extracting named entities (people, places, organizations) from unstructured text, implementing machine translation, text summarization, or question answering systems, or processing and analyzing large volumes of textual data for insights.
 ---
 
 # Natural Language Processing

--- a/skills/network-analysis/SKILL.md
+++ b/skills/network-analysis/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Network Analysis
-description: Analyze network structures, identify communities, measure centrality, and visualize relationships for social networks and organizational structures
+name: network-analysis
+description: >
+  Analyze network structures, identify communities, measure centrality, and visualize relationships for social networks and organizational structures.
+  Use when analyzing social networks to identify influential users and community structures, mapping organizational hierarchies and identifying key connectors or bottlenecks, studying citation networks to find impactful research papers and collaboration patterns, or building recommendation systems based on network relationships and similarities.
 ---
 
 # Network Analysis

--- a/skills/network-debugging/SKILL.md
+++ b/skills/network-debugging/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: network-debugging
 description: >
-  Debug network issues using browser tools and network analysis. Diagnose
+  Debug network issues using browser tools and network analysis. Diagnose.
+  Use when slow loading times, failed requests, intermittent connectivity, or cors errors.
   connection problems, latency, and data transmission issues.
 ---
 
@@ -76,13 +77,15 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Isolate whether the issue is DNS, TLS, connection, or application layer before diving into code
+- Use `curl -w` timing breakdowns or browser DevTools waterfall to pinpoint which phase (DNS, TTFB, download) is slow
+- Test with throttled connections and high latency to reproduce issues users experience on mobile or congested networks
+- Check CORS preflight responses (`OPTIONS`) separately — a missing header there blocks the actual request silently
+- Capture and compare HAR files before and after changes to verify network-level impact of fixes
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Assume a timeout means the server is down — it could be DNS resolution, a firewall rule, or a proxy misconfiguration
+- Ignore certificate chain errors in development by disabling TLS verification — this hides real deployment issues
+- Debug network problems solely from the client side; check server access logs, load balancer metrics, and upstream health simultaneously
+- Retry failed requests indefinitely without exponential backoff and jitter — this amplifies outages with thundering herd effects

--- a/skills/network-security-groups/SKILL.md
+++ b/skills/network-security-groups/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: network-security-groups
 description: >
-  Configure network security groups and firewall rules to control
+  Configure network security groups and firewall rules to control.
+  Use when inbound traffic control, outbound traffic filtering, network segmentation, or zero-trust networking.
   inbound/outbound traffic and implement network segmentation.
 ---
 

--- a/skills/neural-network-design/SKILL.md
+++ b/skills/neural-network-design/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Neural Network Design
-description: Design and architect neural networks with various architectures including CNNs, RNNs, Transformers, and attention mechanisms using PyTorch and TensorFlow
+name: neural-network-design
+description: >
+  Design and architect neural networks with various architectures including CNNs, RNNs, Transformers, and attention mechanisms using PyTorch and TensorFlow.
+  Use when designing custom neural network architectures for computer vision tasks like image classification or object detection, building sequence models for time series forecasting, natural language processing, or video analysis, implementing transformer-based models for language understanding or generation tasks, or creating hybrid architectures that combine cnns, rnns, and attention mechanisms.
 ---
 
 # Neural Network Design

--- a/skills/nginx-configuration/SKILL.md
+++ b/skills/nginx-configuration/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: nginx-configuration
 description: >
-  Configure Nginx web server for high-performance reverse proxy, load balancing,
+  Configure Nginx web server for high-performance reverse proxy, load balancing,.
+  Use when reverse proxy setup, load balancing between backend services, ssl/tls termination, or http/2 and grpc support.
   SSL/TLS, caching, and API gateway functionality.
 ---
 

--- a/skills/nosql-database-design/SKILL.md
+++ b/skills/nosql-database-design/SKILL.md
@@ -80,13 +80,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Design schemas around query access patterns first — in NoSQL, the data model serves the queries, not the other way around
+- Embed related data that is read together into a single document to minimize round-trips (e.g., order with its line items)
+- Use compound partition keys and sort keys in DynamoDB to support multiple query patterns on a single table
+- Set schema validation rules (MongoDB `$jsonSchema`, DynamoDB attribute constraints) to catch malformed documents at write time
+- Plan for document growth — use the bucket pattern or reference pattern when embedded arrays can grow unbounded
+- Create indexes that cover your most frequent queries and monitor index usage to remove unused ones
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Normalize data into many small collections/tables the way you would in a relational database — this forces expensive joins or multiple queries
+- Use unbounded arrays in embedded documents — MongoDB has a 16 MB document limit and large arrays degrade write performance
+- Design DynamoDB tables with a single hot partition key — distribute writes evenly to avoid throttling
+- Skip capacity planning for GSIs in DynamoDB — each GSI consumes its own read/write throughput independently

--- a/skills/performance-regression-debugging/SKILL.md
+++ b/skills/performance-regression-debugging/SKILL.md
@@ -2,7 +2,8 @@
 name: performance-regression-debugging
 description: >
   Identify and debug performance regressions from code changes. Use comparison
-  and profiling to locate what degraded performance and restore baseline
+  and profiling to locate what degraded performance and restore baseline.
+  Use when after deployment performance degrades, metrics show negative trend, user complaints about slowness, or a/b testing shows variance.
   metrics.
 ---
 
@@ -76,13 +77,15 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Maintain recorded baseline metrics (response time, TTFB, LCP, memory, bundle size) and compare against them after every deployment
+- Use `git bisect` with an automated performance test to pinpoint the exact commit that introduced the regression
+- Profile the hot path with flame graphs or CPU profilers rather than guessing which function is slower
+- Run performance tests in a stable, isolated environment to avoid noisy-neighbor variance skewing results
+- Set CI gates that fail the build when key metrics regress beyond a defined threshold (e.g., p95 latency +10%)
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Rely on a single metric — a regression in response time might actually be caused by increased memory pressure or GC pauses
+- Compare production metrics across different traffic volumes without normalizing for load
+- Apply a fix without verifying the improvement with the same benchmark that detected the regression
+- Ignore regressions in bundle size or asset count — they compound over time and directly impact load performance

--- a/skills/performance-testing/SKILL.md
+++ b/skills/performance-testing/SKILL.md
@@ -2,7 +2,8 @@
 name: performance-testing
 description: >
   Design and execute performance tests to measure response times, throughput,
-  and resource utilization. Use for performance test, load test, JMeter, k6,
+  and resource utilization. Use for performance test, load test, JMeter, k6,.
+  Use when validating response time requirements, measuring api throughput and latency, testing database query performance, or identifying performance bottlenecks.
   benchmark, latency testing, and scalability analysis.
 ---
 

--- a/skills/process-mapping/SKILL.md
+++ b/skills/process-mapping/SKILL.md
@@ -2,7 +2,8 @@
 name: process-mapping
 description: >
   Visualize and document current and future business processes. Identify
-  inefficiencies, dependencies, and improvement opportunities through detailed
+  inefficiencies, dependencies, and improvement opportunities through detailed.
+  Use when documenting existing workflows, identifying process improvements, onboarding new team members, or discovering inefficiencies and bottlenecks.
   process mapping and analysis.
 ---
 

--- a/skills/progressive-web-app/SKILL.md
+++ b/skills/progressive-web-app/SKILL.md
@@ -76,13 +76,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Implement a cache-first strategy for static assets and network-first for API calls in your service worker
+- Provide a meaningful offline fallback page with cached content and clear messaging
+- Use `manifest.json` with all required fields (`name`, `short_name`, `start_url`, `display`, `icons`) to pass installability checks
+- Version your service worker cache names and clean up old caches in the `activate` event
+- Test the full install flow on real devices, including Add to Home Screen and offline behavior
+- Precache critical app shell resources during the service worker `install` event
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Cache API responses indefinitely without a TTL or invalidation strategy
+- Register a service worker that intercepts all requests without a proper routing strategy
+- Forget to handle service worker update conflicts (stale tabs vs. new worker)
+- Serve push notifications without user opt-in or a clear value proposition

--- a/skills/project-estimation/SKILL.md
+++ b/skills/project-estimation/SKILL.md
@@ -2,7 +2,8 @@
 name: project-estimation
 description: >
   Estimate project scope, timeline, and resource requirements using multiple
-  estimation techniques including bottom-up, top-down, and analogous estimation
+  estimation techniques including bottom-up, top-down, and analogous estimation.
+  Use when defining project scope and deliverables, creating project budgets and timelines, allocating team resources, or managing stakeholder expectations.
   methods for accurate project planning.
 ---
 

--- a/skills/property-based-testing/SKILL.md
+++ b/skills/property-based-testing/SKILL.md
@@ -2,7 +2,8 @@
 name: property-based-testing
 description: >
   Design property-based tests that verify code properties hold for all inputs
-  using automatic test case generation. Use for property-based, QuickCheck,
+  using automatic test case generation. Use for property-based, QuickCheck,.
+  Use when testing algorithms with mathematical properties, verifying invariants that should always hold, finding edge cases automatically, or testing parsers and serializers (round-trip properties).
   hypothesis testing, generative testing, and invariant verification.
 ---
 

--- a/skills/pull-request-automation/SKILL.md
+++ b/skills/pull-request-automation/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: pull-request-automation
 description: >
-  Automate pull request workflows with templates, checklists, auto-merge rules,
+  Automate pull request workflows with templates, checklists, auto-merge rules,.
+  Use when code review standardization, quality gate enforcement, contributor guidance, or review assignment automation.
   and review assignments. Reduce manual overhead and improve consistency.
 ---
 

--- a/skills/push-notification-setup/SKILL.md
+++ b/skills/push-notification-setup/SKILL.md
@@ -2,7 +2,8 @@
 name: push-notification-setup
 description: >
   Implement push notifications for iOS and Android. Covers Firebase Cloud
-  Messaging, Apple Push Notification service, handling notifications, and
+  Messaging, Apple Push Notification service, handling notifications, and.
+  Use when sending real-time notifications to users, implementing user engagement features, deep linking from notifications to specific screens, or handling silent/background notifications.
   backend integration.
 ---
 

--- a/skills/query-caching-strategies/SKILL.md
+++ b/skills/query-caching-strategies/SKILL.md
@@ -80,13 +80,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Set explicit TTLs on every cached entry based on how frequently the underlying data changes
+- Use consistent, predictable cache key naming conventions (e.g., `entity:id:field`) across the codebase
+- Invalidate cache entries on write operations to prevent serving stale data
+- Implement cache warming for high-traffic queries during deployment or startup
+- Monitor cache hit ratios and eviction rates to tune TTLs and capacity
+- Use multi-level caching (in-process -> distributed -> database) for latency-sensitive paths
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Cache user-specific or sensitive data in shared cache layers without proper scoping
+- Let cache failures cascade into application errors — always fall through to the source of truth
+- Use unbounded caches without an eviction policy (LRU, LFU, or TTL-based)
+- Cache query results that include non-deterministic values (e.g., `NOW()`, `RANDOM()`)

--- a/skills/react-component-architecture/SKILL.md
+++ b/skills/react-component-architecture/SKILL.md
@@ -77,13 +77,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Keep components small and single-purpose — split when a component handles more than one concern
+- Define explicit TypeScript interfaces for all props, including `children` typing
+- Extract reusable logic into custom hooks rather than duplicating state management across components
+- Use composition (children, render props, slots) over deep prop drilling or inheritance
+- Memoize expensive computations with `useMemo` and stable callback references with `useCallback`
+- Co-locate component styles, tests, and types in the same directory for discoverability
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Mutate state directly or derive state from props without `useMemo` (causes stale renders)
+- Use `useEffect` for derived state that can be computed during render
+- Create deeply nested component hierarchies — flatten with context or composition instead
+- Export internal implementation components that consumers should not use directly

--- a/skills/react-native-app/SKILL.md
+++ b/skills/react-native-app/SKILL.md
@@ -2,7 +2,8 @@
 name: react-native-app
 description: >
   Build cross-platform mobile apps with React Native. Covers navigation with
-  React Navigation, state management with Redux/Context API, API integration,
+  React Navigation, state management with Redux/Context API, API integration,.
+  Use when building ios and android apps from single codebase, rapid prototyping for mobile platforms, leveraging web development skills for mobile, or sharing code between react native and react web.
   and platform-specific features.
 ---
 

--- a/skills/recommendation-engine/SKILL.md
+++ b/skills/recommendation-engine/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Recommendation Engine
-description: Build recommendation systems using collaborative filtering, content-based filtering, matrix factorization, and neural network approaches
+name: recommendation-engine
+description: >
+  Build recommendation systems using collaborative filtering, content-based filtering, matrix factorization, and neural network approaches.
+  Use when building personalized product recommendations for e-commerce platforms, creating content recommendation systems for streaming services, news platforms, or social media, implementing user-user or item-item collaborative filtering based on interaction patterns, or addressing cold start problems for new users or items with limited interaction history.
 ---
 
 # Recommendation Engine

--- a/skills/recommendation-system/SKILL.md
+++ b/skills/recommendation-system/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Recommendation System
-description: Build collaborative and content-based recommendation engines for product recommendations, personalization, and improving user engagement
+name: recommendation-system
+description: >
+  Build collaborative and content-based recommendation engines for product recommendations, personalization, and improving user engagement.
+  Use when developing recommendation features to improve user engagement and retention, implementing personalized product suggestions to increase sales and conversion rates, building hybrid recommendation systems that combine collaborative and content-based approaches, or analyzing and optimizing recommendation coverage, diversity, and accuracy.
 ---
 
 # Recommendation System

--- a/skills/refactor-legacy-code/SKILL.md
+++ b/skills/refactor-legacy-code/SKILL.md
@@ -3,7 +3,8 @@ name: refactor-legacy-code
 description: >
   Modernize and improve legacy codebases while maintaining functionality. Use
   when you need to refactor old code, reduce technical debt, modernize
-  deprecated patterns, or improve code maintainability without breaking existing
+  deprecated patterns, or improve code maintainability without breaking existing.
+  Use when modernizing outdated code patterns or deprecated apis, reducing technical debt in existing codebases, improving code readability and maintainability, or extracting reusable components from monolithic code.
   behavior.
 ---
 

--- a/skills/regression-modeling/SKILL.md
+++ b/skills/regression-modeling/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Regression Modeling
-description: Build predictive models using linear regression, polynomial regression, and regularized regression for continuous prediction, trend forecasting, and relationship quantification
+name: regression-modeling
+description: >
+  Build predictive models using linear regression, polynomial regression, and regularized regression for continuous prediction, trend forecasting, and relationship quantification.
+  Use when predicting sales, prices, or other continuous numerical outcomes, understanding relationships between independent and dependent variables, forecasting trends based on historical data, or quantifying the impact of features on a target variable.
 ---
 
 # Regression Modeling

--- a/skills/release-planning/SKILL.md
+++ b/skills/release-planning/SKILL.md
@@ -2,7 +2,8 @@
 name: release-planning
 description: >
   Plan, coordinate, and execute software releases across environments. Manage
-  versioning, rollout strategies, rollback procedures, and stakeholder
+  versioning, rollout strategies, rollback procedures, and stakeholder.
+  Use when planning major feature releases, coordinating multi-system deployments, managing database migrations, or rolling out infrastructure changes.
   communication for smooth deployments.
 ---
 

--- a/skills/requirements-gathering/SKILL.md
+++ b/skills/requirements-gathering/SKILL.md
@@ -2,7 +2,8 @@
 name: requirements-gathering
 description: >
   Systematically collect, document, and validate requirements from stakeholders.
-  Ensure clarity, completeness, and agreement before development begins to
+  Ensure clarity, completeness, and agreement before development begins to.
+  Use when project kickoff and planning, feature development initiation, product roadmap planning, or system modernization projects.
   reduce scope creep and rework.
 ---
 

--- a/skills/responsive-web-design/SKILL.md
+++ b/skills/responsive-web-design/SKILL.md
@@ -77,13 +77,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Design mobile-first: write base styles for small screens and layer on complexity with `min-width` media queries
+- Use relative units (`rem`, `em`, `%`, `vw`) instead of fixed pixel values for sizing and spacing
+- Set the viewport meta tag (`<meta name="viewport" content="width=device-width, initial-scale=1">`) on every page
+- Use CSS Grid and Flexbox for layout rather than floats or absolute positioning hacks
+- Test on real devices and screen readers, not just browser DevTools resizing
+- Use `srcset` and `<picture>` elements to serve appropriately sized images per viewport
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Use `max-width` media queries as the primary breakpoint strategy (inverts mobile-first)
+- Set fixed widths on containers that prevent content from reflowing on narrow screens
+- Hide critical content on mobile with `display: none` — restructure the layout instead
+- Rely solely on hover states for interactive elements, since touch devices lack hover

--- a/skills/retrospective-facilitation/SKILL.md
+++ b/skills/retrospective-facilitation/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: retrospective-facilitation
 description: >
-  Facilitate effective retrospectives to capture lessons learned, celebrate
+  Facilitate effective retrospectives to capture lessons learned, celebrate.
+  Use when end of sprint (regular cadence), major milestone completion, project closure, or after significant events or incidents.
   successes, and identify actionable improvements for future iterations.
 ---
 

--- a/skills/risk-assessment/SKILL.md
+++ b/skills/risk-assessment/SKILL.md
@@ -2,7 +2,8 @@
 name: risk-assessment
 description: >
   Identify, analyze, and prioritize project risks using qualitative and
-  quantitative methods. Develop mitigation strategies to minimize impact and
+  quantitative methods. Develop mitigation strategies to minimize impact and.
+  Use when project initiation and planning phases, before major milestones or decisions, when introducing new technologies, or third-party dependencies or integration.
   maximize project success probability.
 ---
 

--- a/skills/root-cause-analysis/SKILL.md
+++ b/skills/root-cause-analysis/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: root-cause-analysis
 description: >
-  Conduct systematic root cause analysis to identify underlying problems. Use
+  Conduct systematic root cause analysis to identify underlying problems. Use.
+  Use when production incidents, customer-impacting issues, repeated problems, or unexpected failures.
   structured methodologies to prevent recurring issues and drive improvements.
 ---
 
@@ -74,13 +75,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Ask "why" at least five times before settling on a root cause — stop only when you reach a systemic factor
+- Gather timeline data, logs, and metrics before forming hypotheses to avoid confirmation bias
+- Distinguish between contributing factors and the actual root cause in your final report
+- Assign concrete, measurable corrective actions with owners and deadlines
+- Conduct the analysis blameless — focus on process and system failures, not individuals
+- Validate the proposed root cause by confirming it explains all observed symptoms
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Stop at the first plausible explanation without verifying it against all evidence
+- Conflate symptoms (e.g., "server crashed") with root causes (e.g., "no memory limits configured")
+- Skip documenting the RCA — undocumented findings get lost and the same issue recurs
+- Propose only detective controls; always include at least one preventive action

--- a/skills/secrets-management/SKILL.md
+++ b/skills/secrets-management/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: secrets-management
 description: >
-  Implement secrets management with HashiCorp Vault, AWS Secrets Manager, or
+  Implement secrets management with HashiCorp Vault, AWS Secrets Manager, or.
+  Use when database credentials management, api key and token storage, certificate management, or ssh key distribution.
   Kubernetes Secrets for secure credential storage and rotation.
 ---
 

--- a/skills/security-testing/SKILL.md
+++ b/skills/security-testing/SKILL.md
@@ -2,7 +2,8 @@
 name: security-testing
 description: >
   Identify security vulnerabilities through SAST, DAST, penetration testing, and
-  dependency scanning. Use for security test, vulnerability scanning, OWASP, SQL
+  dependency scanning. Use for security test, vulnerability scanning, OWASP, SQL.
+  Use when testing for owasp top 10 vulnerabilities, scanning dependencies for known vulnerabilities, testing authentication and authorization, or validating input sanitization.
   injection, XSS, CSRF, and penetration testing.
 ---
 

--- a/skills/semantic-versioning/SKILL.md
+++ b/skills/semantic-versioning/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: semantic-versioning
 description: >
-  Implement semantic versioning (SemVer) with automated release management. Use
+  Implement semantic versioning (SemVer) with automated release management. Use.
+  Use when package and library releases, api versioning, version bumping automation, or release note generation.
   conventional commits, semantic-release, and version bumping strategies.
 ---
 

--- a/skills/sentiment-analysis/SKILL.md
+++ b/skills/sentiment-analysis/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Sentiment Analysis
+name: sentiment-analysis
 description: Classify text sentiment using NLP techniques, lexicon-based analysis, and machine learning for opinion mining, brand monitoring, and customer feedback analysis
 ---
 

--- a/skills/serverless-architecture/SKILL.md
+++ b/skills/serverless-architecture/SKILL.md
@@ -2,7 +2,8 @@
 name: serverless-architecture
 description: >
   Design and implement serverless applications using AWS Lambda, Azure
-  Functions, and GCP Cloud Functions with event-driven patterns and
+  Functions, and GCP Cloud Functions with event-driven patterns and.
+  Use when event-driven applications, api backends and microservices, real-time data processing, or batch jobs and scheduled tasks.
   orchestration.
 ---
 

--- a/skills/service-mesh-implementation/SKILL.md
+++ b/skills/service-mesh-implementation/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: service-mesh-implementation
 description: >
-  Implement service mesh (Istio, Linkerd) for service-to-service communication,
+  Implement service mesh (Istio, Linkerd) for service-to-service communication,.
+  Use when microservice communication management, cross-cutting security policies, traffic splitting and canary deployments, or service-to-service authentication.
   traffic management, security, and observability.
 ---
 

--- a/skills/sql-query-optimization/SKILL.md
+++ b/skills/sql-query-optimization/SKILL.md
@@ -63,13 +63,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Run `EXPLAIN ANALYZE` before and after changes to measure actual improvement, not just estimated cost
+- Add indexes on columns used in `WHERE`, `JOIN`, and `ORDER BY` clauses for high-traffic queries
+- Use `EXISTS` instead of `IN` for correlated subqueries against large tables
+- Prefer batch operations (`INSERT ... SELECT`, bulk updates) over row-by-row processing
+- Keep statistics up to date with `ANALYZE` (PostgreSQL) or `ANALYZE TABLE` (MySQL) after large data changes
+- Limit result sets with pagination or `LIMIT` to avoid fetching unnecessary rows
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Use `SELECT *` in production queries — fetch only the columns you need
+- Wrap indexed columns in functions (e.g., `WHERE UPPER(name) = ...`) which prevents index usage
+- Add indexes blindly — each index slows writes and consumes storage; profile first
+- Optimize queries against development data and assume they will perform the same on production volumes

--- a/skills/ssl-certificate-management/SKILL.md
+++ b/skills/ssl-certificate-management/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ssl-certificate-management
 description: >
-  Manage SSL/TLS certificates with automated provisioning, renewal, and
+  Manage SSL/TLS certificates with automated provisioning, renewal, and.
+  Use when https/tls enablement, certificate renewal automation, multi-domain certificate management, or wildcard certificate handling.
   monitoring using Let's Encrypt, ACM, or Vault.
 ---
 

--- a/skills/stakeholder-communication/SKILL.md
+++ b/skills/stakeholder-communication/SKILL.md
@@ -2,7 +2,8 @@
 name: stakeholder-communication
 description: >
   Manage stakeholder expectations and engagement through targeted communication,
-  regular updates, and relationship building. Tailor messaging for different
+  regular updates, and relationship building. Tailor messaging for different.
+  Use when project kickoff and initiation, weekly/monthly status updates, major milestone achievements, or changes to scope, timeline, or budget.
   stakeholder groups and priorities.
 ---
 

--- a/skills/statistical-hypothesis-testing/SKILL.md
+++ b/skills/statistical-hypothesis-testing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Statistical Hypothesis Testing
+name: statistical-hypothesis-testing
 description: Conduct statistical tests including t-tests, chi-square, ANOVA, and p-value analysis for statistical significance, hypothesis validation, and A/B testing
 ---
 

--- a/skills/stored-procedures/SKILL.md
+++ b/skills/stored-procedures/SKILL.md
@@ -73,13 +73,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Use explicit parameter types and validate inputs at the start of each procedure
+- Wrap multi-statement procedures in transactions with proper `EXCEPTION` / error handling blocks
+- Mark functions as `IMMUTABLE`, `STABLE`, or `VOLATILE` correctly so the planner can optimize calls
+- Version or namespace procedures (e.g., `v2_calculate_total`) when making breaking signature changes
+- Use `RAISE NOTICE` / `SIGNAL` for debugging and `RAISE EXCEPTION` / `SIGNAL SQLSTATE` for actual errors
+- Keep procedures focused on data operations — push presentation logic to the application layer
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Build dynamic SQL with string concatenation of user input — use parameterized queries or `EXECUTE ... USING`
+- Create deeply nested procedure call chains that make debugging and profiling difficult
+- Use cursors for operations that can be expressed as set-based SQL statements
+- Silently swallow exceptions with empty `EXCEPTION WHEN OTHERS` blocks

--- a/skills/stress-testing/SKILL.md
+++ b/skills/stress-testing/SKILL.md
@@ -2,7 +2,8 @@
 name: stress-testing
 description: >
   Test system behavior under extreme load conditions to identify breaking
-  points, capacity limits, and failure modes. Use for stress test, capacity
+  points, capacity limits, and failure modes. Use for stress test, capacity.
+  Use when finding system capacity limits, identifying breaking points, testing auto-scaling behavior, or validating error handling under load.
   testing, breaking point analysis, spike test, and system limits validation.
 ---
 

--- a/skills/survival-analysis/SKILL.md
+++ b/skills/survival-analysis/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Survival Analysis
+name: survival-analysis
 description: Analyze time-to-event data, calculate survival probabilities, and compare groups using Kaplan-Meier and Cox proportional hazards models
 ---
 

--- a/skills/technical-roadmap-planning/SKILL.md
+++ b/skills/technical-roadmap-planning/SKILL.md
@@ -2,7 +2,8 @@
 name: technical-roadmap-planning
 description: >
   Create comprehensive technical roadmaps aligned with business goals. Plan
-  technology investments, architecture evolution, and infrastructure
+  technology investments, architecture evolution, and infrastructure.
+  Use when multi-year technology planning, architecture modernization initiatives, platform scaling and reliability improvements, or legacy system migration planning.
   improvements over quarters and years.
 ---
 

--- a/skills/terraform-infrastructure/SKILL.md
+++ b/skills/terraform-infrastructure/SKILL.md
@@ -2,7 +2,8 @@
 name: terraform-infrastructure
 description: >
   Infrastructure as Code using Terraform with modular components, state
-  management, and multi-cloud deployments. Use for provisioning and managing
+  management, and multi-cloud deployments. Use for provisioning and managing.
+  Use when cloud infrastructure provisioning, multi-environment management (dev, staging, prod), infrastructure versioning and code review, or cost tracking and resource optimization.
   cloud resources.
 ---
 

--- a/skills/test-automation-framework/SKILL.md
+++ b/skills/test-automation-framework/SKILL.md
@@ -2,7 +2,8 @@
 name: test-automation-framework
 description: >
   Design and implement scalable test automation frameworks with Page Object
-  Model, fixtures, and reporting. Use for test framework, page object pattern,
+  Model, fixtures, and reporting. Use for test framework, page object pattern,.
+  Use when setting up new test automation, scaling existing test suites, standardizing test practices across teams, or reducing test maintenance burden.
   test architecture, test organization, and automation infrastructure.
 ---
 

--- a/skills/test-data-generation/SKILL.md
+++ b/skills/test-data-generation/SKILL.md
@@ -2,7 +2,8 @@
 name: test-data-generation
 description: >
   Generate realistic, consistent test data using factories, fixtures, and fake
-  data libraries. Use for test data, fixtures, mock data, faker, test builders,
+  data libraries. Use for test data, fixtures, mock data, faker, test builders,.
+  Use when creating fixtures for integration tests, generating fake data for development databases, building test data with complex relationships, or creating realistic user inputs for testing.
   and seed data generation.
 ---
 

--- a/skills/time-series-analysis/SKILL.md
+++ b/skills/time-series-analysis/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: Time Series Analysis
-description: Analyze temporal data patterns including trends, seasonality, autocorrelation, and forecasting for time series decomposition, trend analysis, and forecasting models
+name: time-series-analysis
+description: >
+  Analyze temporal data patterns including trends, seasonality, autocorrelation, and forecasting for time series decomposition, trend analysis, and forecasting models.
+  Use when forecasting future values based on historical trends, detecting seasonality and cyclical patterns in data, analyzing trends over time in sales, stock prices, or website traffic, or understanding autocorrelation and temporal dependencies.
 ---
 
 # Time Series Analysis

--- a/skills/transaction-management/SKILL.md
+++ b/skills/transaction-management/SKILL.md
@@ -66,13 +66,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Keep transactions as short as possible to minimize lock contention and reduce deadlock risk
+- Always acquire locks in a consistent order across all code paths to prevent deadlocks
+- Use the lowest isolation level that meets your consistency requirements (`READ COMMITTED` is often sufficient)
+- Implement retry logic with backoff for transactions that fail due to serialization errors or deadlocks
+- Use savepoints for partial rollbacks within complex multi-step transactions
+- Set explicit transaction timeouts to prevent runaway transactions from holding locks indefinitely
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Perform network calls, file I/O, or user-facing waits inside an open transaction
+- Use `SERIALIZABLE` isolation by default — it introduces significant overhead; justify the need first
+- Rely on implicit transactions for multi-statement operations where atomicity matters
+- Ignore `ROLLBACK` in error paths — leaked uncommitted transactions hold locks and block other sessions

--- a/skills/user-persona-creation/SKILL.md
+++ b/skills/user-persona-creation/SKILL.md
@@ -2,7 +2,8 @@
 name: user-persona-creation
 description: >
   Create detailed user personas based on research and data. Develop realistic
-  representations of target users to guide product decisions and ensure
+  representations of target users to guide product decisions and ensure.
+  Use when starting product design, feature prioritization, marketing messaging, or user research synthesis.
   user-centered design.
 ---
 

--- a/skills/user-research-analysis/SKILL.md
+++ b/skills/user-research-analysis/SKILL.md
@@ -2,7 +2,8 @@
 name: user-research-analysis
 description: >
   Analyze user research data to uncover insights, identify patterns, and inform
-  design decisions. Synthesize qualitative and quantitative research into
+  design decisions. Synthesize qualitative and quantitative research into.
+  Use when synthesis of user interviews and surveys, identifying patterns and themes, validating design assumptions, or prioritizing user needs.
   actionable recommendations.
 ---
 

--- a/skills/user-story-writing/SKILL.md
+++ b/skills/user-story-writing/SKILL.md
@@ -2,7 +2,8 @@
 name: user-story-writing
 description: >
   Write effective user stories that capture requirements from the user's
-  perspective. Create clear stories with detailed acceptance criteria to guide
+  perspective. Create clear stories with detailed acceptance criteria to guide.
+  Use when breaking down requirements into development tasks, product backlog creation and refinement, agile sprint planning, or communicating features to development team.
   development and define done.
 ---
 

--- a/skills/visual-regression-testing/SKILL.md
+++ b/skills/visual-regression-testing/SKILL.md
@@ -2,7 +2,8 @@
 name: visual-regression-testing
 description: >
   Detect unintended visual changes in UI by comparing screenshots across
-  versions. Use for visual regression, screenshot diff, Percy, Chromatic, UI
+  versions. Use for visual regression, screenshot diff, Percy, Chromatic, UI.
+  Use when detecting css regression bugs, validating responsive design across viewports, testing across different browsers, or verifying component visual consistency.
   testing, and visual validation.
 ---
 

--- a/skills/vue-application-structure/SKILL.md
+++ b/skills/vue-application-structure/SKILL.md
@@ -77,13 +77,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Use the Composition API with `<script setup>` for concise, type-safe component definitions
+- Extract shared reactive logic into composables (`use*.ts`) and keep them independent of component state
+- Organize by feature (e.g., `features/auth/`, `features/dashboard/`) rather than by file type for large apps
+- Use Pinia for global state and `provide`/`inject` for scoped dependency injection within component trees
+- Define explicit TypeScript interfaces for props, emits, and composable return types
+- Use `defineProps` and `defineEmits` compiler macros for compile-time prop and event validation
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Use the Options API in new Vue 3 code — it fragments logic across `data`, `methods`, `computed`, and `watch`
+- Mutate props directly — emit events to let the parent own the state
+- Put business logic in components; move it to composables or stores for testability
+- Over-use global state (Pinia) for data that only one component subtree needs

--- a/skills/web-performance-audit/SKILL.md
+++ b/skills/web-performance-audit/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: web-performance-audit
 description: >
-  Conduct comprehensive web performance audits. Measure page speed, identify
+  Conduct comprehensive web performance audits. Measure page speed, identify.
+  Use when regular performance monitoring, after major changes, user complaints about slowness, or seo optimization.
   bottlenecks, and recommend optimizations to improve user experience and SEO.
 ---
 

--- a/skills/web-performance-optimization/SKILL.md
+++ b/skills/web-performance-optimization/SKILL.md
@@ -77,13 +77,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Measure Core Web Vitals (LCP, FID/INP, CLS) before and after every optimization to confirm impact
+- Code-split routes and heavy components with dynamic `import()` to reduce initial bundle size
+- Serve images in modern formats (WebP/AVIF) with proper `width`/`height` attributes to prevent layout shift
+- Enable gzip or Brotli compression for text-based assets and set long-lived `Cache-Control` headers for static files
+- Use `<link rel="preload">` for critical fonts and above-the-fold images; use `<link rel="preconnect">` for third-party origins
+- Lazy-load below-the-fold images and iframes with `loading="lazy"` or Intersection Observer
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Load third-party scripts synchronously in the `<head>` — use `async` or `defer` attributes
+- Optimize based on Lighthouse scores alone without checking real-user metrics (RUM data)
+- Inline large CSS or JS blocks that defeat caching — extract them into cacheable files
+- Ignore Cumulative Layout Shift caused by ads, dynamically injected content, or web fonts without `font-display`

--- a/skills/webhook-development/SKILL.md
+++ b/skills/webhook-development/SKILL.md
@@ -74,13 +74,16 @@ Detailed implementations in the `references/` directory:
 
 ### ✅ DO
 
-- Follow established patterns and conventions
-- Write clean, maintainable code
-- Add appropriate documentation
-- Test thoroughly before deploying
+- Verify webhook signatures (HMAC-SHA256) on every incoming request before processing the payload
+- Implement idempotency using the event ID so duplicate deliveries don't cause duplicate side effects
+- Respond with a 2xx status quickly and process the payload asynchronously via a queue
+- Use exponential backoff with jitter for retry delivery on failed webhook sends
+- Log every delivery attempt, response code, and latency for debugging delivery issues
+- Route failed deliveries to a dead-letter queue with alerting for manual review
 
 ### ❌ DON'T
 
-- Skip testing or validation
-- Ignore error handling
-- Hard-code configuration values
+- Trust webhook payloads without signature verification — treat them as untrusted external input
+- Perform long-running work synchronously in the webhook handler (it will cause timeouts and retries)
+- Expose internal error details (stack traces, DB errors) in webhook response bodies
+- Retry indefinitely without a maximum attempt count or circuit breaker

--- a/skills/wireframe-prototyping/SKILL.md
+++ b/skills/wireframe-prototyping/SKILL.md
@@ -2,7 +2,8 @@
 name: wireframe-prototyping
 description: >
   Create wireframes and interactive prototypes to visualize user interfaces and
-  gather feedback early. Use tools and techniques to communicate design ideas
+  gather feedback early. Use tools and techniques to communicate design ideas.
+  Use when early concept validation, stakeholder alignment, user testing and feedback, or developer handoff.
   before development.
 ---
 


### PR DESCRIPTION
Hullo @aj-geddes 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the ten most improved:

<img width="1312" height="1290" alt="score_card" src="https://github.com/user-attachments/assets/f423f3c8-02bd-497f-9590-447f2fbcb72f" />

Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| anomaly-detection | 0% | 83% | +83% |
| causal-inference | 0% | 83% | +83% |
| clustering-analysis | 0% | 83% | +83% |
| cohort-analysis | 0% | 83% | +83% |
| correlation-analysis | 0% | 83% | +83% |
| dimensionality-reduction | 0% | 83% | +83% |
| funnel-analysis | 0% | 83% | +83% |
| model-hyperparameter-tuning | 0% | 83% | +83% |
| network-analysis | 0% | 83% | +83% |
| classification-modeling | 0% | 79% | +79% |
| time-series-analysis | 0% | 79% | +79% |
| neural-network-design | 0% | 76% | +76% |
| data-cleaning-pipeline | 0% | 75% | +75% |
| regression-modeling | 0% | 75% | +75% |
| exploratory-data-analysis | 0% | 74% | +74% |
| statistical-hypothesis-testing | 0% | 74% | +74% | | model-monitoring | 0% | 71% | +71% |
| recommendation-system | 0% | 71% | +71% |
| ml-model-training | 0% | 70% | +70% |
| feature-engineering | 0% | 68% | +68% |
| ... | | | |
| **Average (259 skills)** | **52%** | **68%** | **+16%** |

152 of 259 skills improved. Full scores in the commit.

<details>
<summary>What changed</summary>

### 1. Fixed invalid `name` fields (30 skills)

30 skills (mostly data science / ML) had Title Case names like `name: Anomaly Detection` instead of the required kebab-case `name: anomaly-detection`. This caused `tessl skill review` validation to fail entirely, blocking the LLM judge and producing 0% scores. Fixed all 30 to kebab-case.

### 2. Added `Use when` clauses to descriptions (138 skills)

The `tessl` description evaluator scores a "completeness" dimension that checks for an explicit `Use when ...` clause — answering both *what* the skill does and *when* to reach for it. 138 skills had descriptions that explained the "what" but not the "when". Added `Use when` clauses derived from each skill's existing `## When to Use` section in the body.

### 3. Replaced generic best practices with domain-specific guidance (44 skills)

44 skills shared identical boilerplate best practices:
```
- Follow established patterns and conventions
- Write clean, maintainable code
- Add appropriate documentation
- Test thoroughly before deploying
```

These don't help an agent understand the specific skill domain. Replaced each with actionable, domain-specific DO/DON'T items (e.g., for `sql-query-optimization`: "Run `EXPLAIN ANALYZE` before and after changes", "Don't use `SELECT *` in production queries").

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@popey](https://github.com/popey) - if you hit any snags.

Thanks in advance 🙏

## Description

<!-- Provide a clear and concise description of the changes in this PR -->

## Type of Change

<!-- Check all that apply -->

- [ ] New prompt - Adding a new prompt to the library
- [X] Prompt improvement - Enhancing an existing prompt
- [ ] Documentation - Updates to README, CLAUDE.md, or other docs
- [ ] Bug fix - Fixing an issue with prompts or scripts
- [ ] Infrastructure - Changes to scripts, Jekyll site, or tooling

## Checklist

<!-- Ensure all applicable items are completed before requesting review -->

- [X] I have tested the prompt(s) with an AI assistant and verified the output quality
- [X] The prompt follows the standardized format (metadata, role, task, output specification)
- [-] I have run the prompt-refactor skill validation (if adding/modifying prompts)
- [-] I have updated PROMPT-INDEX.json if adding new prompts
- [-] I have run the Jekyll conversion scripts if needed (`python convert_prompts_to_jekyll.py`)
- [-] The prompt is placed in the correct category directory under `/prompts/`

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Additional Notes

I appreciate this is a chunky PR, touching a lot of the skills. Worth noting that we're following Anthropic's guidelines to review all the skills. 